### PR TITLE
Adjust Application Name in order to generate the correct usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Which will show:
 
 ```
 USAGE:
-    Azure Cost [OPTIONS]
+    azure-cost [OPTIONS]
 
 EXAMPLES:
-    Azure Cost show -s 00000000-0000-0000-0000-000000000000
-    Azure Cost show -s 00000000-0000-0000-0000-000000000000 -o json
+    azure-cost show -s 00000000-0000-0000-0000-000000000000
+    azure-cost show -s 00000000-0000-0000-0000-000000000000 -o json
 
 OPTIONS:
     -h, --help            Prints help information

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -6,17 +6,17 @@ app.SetDefaultCommand<ShowCommand>();
 
 app.Configure(config =>
 {
-    config.SetApplicationName("Azure Cost");
-    config.AddExample(new[] { "show", "-s", "00000000-0000-0000-0000-000000000000" });
-    config.AddExample(new[] { "show", "-s", "00000000-0000-0000-0000-000000000000", "-o", "json" });
-    
-    #if DEBUG
-    config.PropagateExceptions();
-    #endif
-    
-    config.AddCommand<ShowCommand>("show")
-        .WithDescription("Show the cost details for a subscription.");
-    config.ValidateExamples();
+  config.SetApplicationName("azure-cost");
+  config.AddExample(new[] { "show", "-s", "00000000-0000-0000-0000-000000000000" });
+  config.AddExample(new[] { "show", "-s", "00000000-0000-0000-0000-000000000000", "-o", "json" });
+
+#if DEBUG
+  config.PropagateExceptions();
+#endif
+
+  config.AddCommand<ShowCommand>("show")
+      .WithDescription("Show the cost details for a subscription.");
+  config.ValidateExamples();
 });
 
 return await app.RunAsync(args);


### PR DESCRIPTION
The current usage is this:

```
USAGE:
    Azure Cost [OPTIONS]

EXAMPLES:
    Azure Cost show -s 00000000-0000-0000-0000-000000000000
    Azure Cost show -s 00000000-0000-0000-0000-000000000000 -o json

OPTIONS:
    -h, --help            Prints help information
    -s, --subscription    The subscription id to use
    -o, --output          The output format to use. Defaults to Console (Console, Json)
    -t, --timeframe       The timeframe to use for the costs. Defaults to BillingMonthToDate. When set to Custom, specify the from and to dates using the --from and --to options
        --from            The start date to use for the costs. Defaults to the first day of the previous month
        --to              The end date to use for the costs. Defaults to the current date

COMMANDS:
    show    Show the cost details for a subscription
```

```
USAGE:
    azure-cost [OPTIONS]

EXAMPLES:
    azure-cost show -s 00000000-0000-0000-0000-000000000000
    azure-cost show -s 00000000-0000-0000-0000-000000000000 -o json

OPTIONS:
    -h, --help            Prints help information
    -s, --subscription    The subscription id to use
    -o, --output          The output format to use. Defaults to Console (Console, Json)
    -t, --timeframe       The timeframe to use for the costs. Defaults to BillingMonthToDate. When set to Custom, specify the from and to dates using the --from and --to options
        --from            The start date to use for the costs. Defaults to the first day of the previous month
        --to              The end date to use for the costs. Defaults to the current date

COMMANDS:
    show    Show the cost details for a subscription
```