### PR TITLE
implement makdown output

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,54 @@ By Location:
 
 ```
 
+
+### Markdown
+
+A simple mardkwon format. It will output the results in a serie of simple table.
+
+```markdown
+# Azure Cost Overview for 574385a9-08e9-49fe-91a2-27660d92b8f5 from 01/04/2023 to 14/04/2023                                                                    
+
+## Totals
+
+|Period|Amount|
+|---|---:|
+|Today|0,52 EUR|
+|Yesterday|2,37 EUR|
+|Last 7 days|17,09 EUR|
+|Last 30 days|30,89 EUR|
+
+## By Service Name
+
+|Period|Amount|
+|---|---:|
+|API Management|19,52 EUR|
+|Azure App Service|5,32 EUR|
+|Azure Monitor|3,67 EUR|
+|Container Registry|2,06 EUR|
+|Log Analytics|0,17 EUR|
+|Storage|0,13 EUR|
+|Key Vault|0,00 EUR|
+|Bandwidth|0,00 EUR|
+
+## By Location
+
+|Period|Amount|
+|---|---:|
+|EU West|30,69 EUR|
+|Unknown|0,20 EUR|
+|US West|0,00 EUR|
+|US West 2|0,00 EUR|
+
+```
+
 ## To do
 
 - [x] Show time range the report is based on
 - [x] Open source it on GitHub!
 - [x] Show the forecasted cost
 - [ ] Set thresholds, so it can return an error code
-- [ ] Generate markdown, so you can include it in a workflow job summary
+- [x] Generate markdown, so you can include it in a workflow job summary
 - [ ] More options to set and filter on
 - [x] Validate date ranges
 - [x] Workflow to push to NuGet

--- a/src/Commands/ShowCommand/OutputFormatters/MarkdownOutputFormatter.cs
+++ b/src/Commands/ShowCommand/OutputFormatters/MarkdownOutputFormatter.cs
@@ -1,0 +1,71 @@
+using AzureCostCli.CostApi;
+using AzureCostCli.Infrastructure;
+
+namespace AzureCostCli.Commands.ShowCommand.OutputFormatters;
+
+public class MarkdownOutputFormatter : OutputFormatter
+{
+    public override Task WriteOutput(ShowSettings settings, 
+        IEnumerable<CostItem> costs,
+        IEnumerable<CostItem> forecastedCosts,
+        IEnumerable<CostNamedItem> byServiceNameCosts,
+        IEnumerable<CostNamedItem> byLocationCosts,
+        IEnumerable<CostNamedItem> byResourceGroupCosts)
+    {
+        var output = new
+        {
+            costs = new
+            {
+                todaysCost = costs.Where(a => a.Date == DateOnly.FromDateTime(DateTime.UtcNow)).Sum(a => a.Cost),
+                yesterdayCost = costs.Where(a => a.Date == DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)))
+                    .Sum(a => a.Cost),
+                lastSevenDaysCost = costs.Where(a => a.Date >= DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-7)))
+                    .Sum(a => a.Cost),
+                lastThirtyDaysCost = costs.Where(a => a.Date >= DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-30)))
+                    .Sum(a => a.Cost),
+            },
+        };
+
+        var currency = costs.FirstOrDefault()?.Currency;
+        
+        Console.WriteLine(
+            $"# Azure Cost Overview for {settings.Subscription} from {costs.Min(a => a.Date)} to {costs.Max(a => a.Date)}");
+        Console.WriteLine("");
+        Console.WriteLine("## Totals:");
+        Console.WriteLine("|Period|Amount|");
+        Console.WriteLine("|---|---:|");
+        Console.WriteLine($"|Today|{output.costs.todaysCost:N2} {currency}|");
+        Console.WriteLine($"|Yesterday|{output.costs.yesterdayCost:N2} {currency}|");
+        Console.WriteLine($"|Last 7 days|{output.costs.lastSevenDaysCost:N2} {currency}|");
+        Console.WriteLine($"|Last 30 days|{output.costs.lastThirtyDaysCost:N2} {currency}|");
+        
+        Console.WriteLine();
+        Console.WriteLine("## By Service Name:");
+        Console.WriteLine("|Service|Amount|");
+        Console.WriteLine("|---|---:|");
+        foreach (var cost in byServiceNameCosts.TrimList(threshold: settings.OthersCutoff))
+        {
+            Console.WriteLine($"|{cost.ItemName}|{cost.Cost:N2} {currency}|");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("## By Location:");
+        Console.WriteLine("|Location|Amount|");
+        Console.WriteLine("|---|---:|");
+        foreach (var cost in byLocationCosts.TrimList(threshold: settings.OthersCutoff))
+        {
+            Console.WriteLine($"|{cost.ItemName}|{cost.Cost:N2} {currency}|");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("## By Resource Group:");
+        Console.WriteLine("|Resource Group|Amount|");
+        Console.WriteLine("|---|---:|");
+        foreach (var cost in byResourceGroupCosts.TrimList(threshold: settings.OthersCutoff))
+        {
+            Console.WriteLine($"|{cost.ItemName}|{cost.Cost:N2} {currency}|");
+        }
+        
+        return Task.CompletedTask;
+    }
+}

--- a/src/Commands/ShowCommand/OutputFormatters/MarkdownOutputFormatter.cs
+++ b/src/Commands/ShowCommand/OutputFormatters/MarkdownOutputFormatter.cs
@@ -30,8 +30,9 @@ public class MarkdownOutputFormatter : OutputFormatter
         
         Console.WriteLine(
             $"# Azure Cost Overview for {settings.Subscription} from {costs.Min(a => a.Date)} to {costs.Max(a => a.Date)}");
-        Console.WriteLine("");
-        Console.WriteLine("## Totals:");
+        Console.WriteLine();
+        Console.WriteLine("## Totals");
+        Console.WriteLine();
         Console.WriteLine("|Period|Amount|");
         Console.WriteLine("|---|---:|");
         Console.WriteLine($"|Today|{output.costs.todaysCost:N2} {currency}|");
@@ -40,7 +41,8 @@ public class MarkdownOutputFormatter : OutputFormatter
         Console.WriteLine($"|Last 30 days|{output.costs.lastThirtyDaysCost:N2} {currency}|");
         
         Console.WriteLine();
-        Console.WriteLine("## By Service Name:");
+        Console.WriteLine("## By Service Name");
+        Console.WriteLine();
         Console.WriteLine("|Service|Amount|");
         Console.WriteLine("|---|---:|");
         foreach (var cost in byServiceNameCosts.TrimList(threshold: settings.OthersCutoff))
@@ -49,7 +51,8 @@ public class MarkdownOutputFormatter : OutputFormatter
         }
 
         Console.WriteLine();
-        Console.WriteLine("## By Location:");
+        Console.WriteLine("## By Location");
+        Console.WriteLine();
         Console.WriteLine("|Location|Amount|");
         Console.WriteLine("|---|---:|");
         foreach (var cost in byLocationCosts.TrimList(threshold: settings.OthersCutoff))
@@ -58,7 +61,8 @@ public class MarkdownOutputFormatter : OutputFormatter
         }
 
         Console.WriteLine();
-        Console.WriteLine("## By Resource Group:");
+        Console.WriteLine("## By Resource Group");
+        Console.WriteLine();
         Console.WriteLine("|Resource Group|Amount|");
         Console.WriteLine("|---|---:|");
         foreach (var cost in byResourceGroupCosts.TrimList(threshold: settings.OthersCutoff))

--- a/src/Commands/ShowCommand/ShowCommand.cs
+++ b/src/Commands/ShowCommand/ShowCommand.cs
@@ -21,6 +21,7 @@ public class ShowCommand : AsyncCommand<ShowSettings>
         _outputFormatters.Add(OutputFormat.Console, new ConsoleOutputFormatter());
         _outputFormatters.Add(OutputFormat.Json, new JsonOutputFormatter());
         _outputFormatters.Add(OutputFormat.Text, new TextOutputFormatter());
+        _outputFormatters.Add(OutputFormat.Markdown, new MarkdownOutputFormatter());
     }
 
     public override ValidationResult Validate(CommandContext context, ShowSettings settings)

--- a/src/Commands/ShowCommand/ShowSettings.cs
+++ b/src/Commands/ShowCommand/ShowSettings.cs
@@ -10,7 +10,7 @@ public class ShowSettings : LogCommandSettings
     public Guid Subscription { get; set; }
 
     [CommandOption("-o|--output")] 
-    [Description("The output format to use. Defaults to Console (Console, Json, Text)")]
+    [Description("The output format to use. Defaults to Console (Console, Json, Text, Markdown)")]
     public OutputFormat Output { get; set; } = OutputFormat.Console;
     
     [CommandOption("-t|--timeframe")]


### PR DESCRIPTION
really like you cost CLI and though I could contribute to close #19 

This PR implements a markdown export based on the text export (same content).
The output is formated into tabs.

An exemple is visible on the readme.md file.

all test passed locally.

