### PR TITLE
adding support for --includeTags option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ OPTIONS:
         --useUSD          Force the use of USD for the currency. Defaults to false to use the currency returned by the API        
         --skipHeader      Skip header creation for specific output formats. Useful when appending the output from multiple runs into one file. Defaults to false 
         --filter          Filter the output by the specified properties. Defaults to no filtering and can be multiple values.
+        --includeTags     Include Tags from the selected dimension. Valid only for DailyCost report and output to Json, JsonC or Csv. Ignored in the rest of reports and output formats.
     -m, --metric           ActualCost    The metric to use for the costs. Defaults to ActualCost. (ActualCost, AmortizedCost)    
 
 COMMANDS:
@@ -206,6 +207,22 @@ azure-cost dailyCosts
 The above screenshots show the default console output, but the other formatters can also be used.
 
 The available dimensions are: `ResourceGroup`,`ResourceGroupName`,`ResourceLocation`,`ConsumedService`,`ResourceType`,`ResourceId`,`MeterId`,`BillingMonth`,`MeterCategory`,`MeterSubcategory`,`Meter`,`AccountName`,`DepartmentName`,`SubscriptionId`,`SubscriptionName`,`ServiceName`,`ServiceTier`,`EnrollmentAccountName`,`BillingAccountId`,`ResourceGuid`,`BillingPeriod`,`InvoiceNumber`,`ChargeType`,`PublisherType`,`ReservationId`,`ReservationName`,`Frequency`,`PartNumber`,`CostAllocationRuleName`,`MarkupRuleName`,`PricingModel`,`BenefitId`,`BenefitName`
+
+### Include Tags
+This option allows to include the dimensions' Tags in the same row. Tags allow cost analysis customization. Adding the Tags from the dimension allows complementary analysis in tools like Power BI. This option is enabled for DailyCost report and for Json, JsonC, and Csv expor formats. Using other formats, ignores the option. 
+
+The following query shows the daily costs for subscription x group by resource group name including the tags for the resource group ready to export to Csv:
+
+```bash 
+azure-cost dailyCosts -s XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX --dimension ResourceGroupName --includeTags -o Csv
+```
+
+That would extend into a column called Tags the resource group tags in Json format:
+```bash 
+[""\""cost-center\"":\""my_cost_center\"""",""\""owner\"":\""my_email@email.com\""""]
+```
+Note that the Json column should be parsed in the analytical tool.
+
 
 ### Detect Anomalies
 

--- a/src/Commands/CostSettings.cs
+++ b/src/Commands/CostSettings.cs
@@ -71,7 +71,12 @@ public class CostSettings : LogCommandSettings, ICostSettings
     [Description("The metric to use for the costs. Defaults to ActualCost. (ActualCost, AmortizedCost)")]
     [DefaultValue(MetricType.ActualCost)]
     public MetricType Metric { get; set; } = MetricType.ActualCost;
-    
+
+    [CommandOption("--includeTags")]
+    [Description("Include Tags from the selected dimension. The option is used for DailyCost report and output to Json, JsonC or Csv. Valid only for DailyCost report and output to Json, JsonC or Csv. Ignored in other reports and output formats.")]
+    [DefaultValue(false)]
+    public bool IncludeTags { get; set; }
+
 
     public Scope GetScope
     {

--- a/src/Commands/DailyCost/DailyCost.cs
+++ b/src/Commands/DailyCost/DailyCost.cs
@@ -4,6 +4,7 @@ using AzureCostCli.Infrastructure;
 using AzureCostCli.OutputFormatters;
 using Spectre.Console;
 using Spectre.Console.Cli;
+using System;
 
 namespace AzureCostCli.Commands.DailyCost;
 
@@ -86,6 +87,12 @@ public class DailyCostCommand : AsyncCommand<DailyCostSettings>
 
         IEnumerable<CostDailyItem> dailyCost = new List<CostDailyItem>();
 
+        // if output format is not csv, json, or jsonc, then don't include tags
+        if (settings.Output.ToString().ToLower() != "json" && settings.Output.ToString().ToLower() != "jsonc" && settings.Output.ToString().ToLower() != "csv")
+        { 
+            settings.IncludeTags = false;
+        }
+
         await AnsiConsoleExt.Status()
             .StartAsync("Fetching daily cost data...", async ctx =>
             {
@@ -96,12 +103,13 @@ public class DailyCostCommand : AsyncCommand<DailyCostSettings>
                     settings.Metric,
                     settings.Dimension,
                     settings.Timeframe,
-                    settings.From, settings.To);
+                    settings.From, settings.To,
+                    settings.IncludeTags);
             });
 
         // Write the output
         await _outputFormatters[settings.Output]
-            .WriteDailyCost(settings, dailyCost);
+        .WriteDailyCost(settings, dailyCost);        
 
         return 0; // Omitted
     }

--- a/src/Commands/DetectAnomaly/DetectAnomaly.cs
+++ b/src/Commands/DetectAnomaly/DetectAnomaly.cs
@@ -96,7 +96,8 @@ public class DetectAnomalyCommand : AsyncCommand<DetectAnomalySettings>
             settings.Metric,
             settings.Dimension,
             settings.Timeframe,
-            settings.From, settings.To);
+            settings.From, settings.To,
+            false);
 
         var costAnalyzer = new CostAnalyzer(settings);
 

--- a/src/CostApi/AzureCostApiRetriever.cs
+++ b/src/CostApi/AzureCostApiRetriever.cs
@@ -156,7 +156,7 @@ public class AzureCostApiRetriever : ICostRetriever
         TimeframeType timeFrame, DateOnly from, DateOnly to)
     {
         var filters = GenerateFilters(filter);
-        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2021-10-01&$top=5000");
+        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
         
         var payload = new
         {
@@ -210,7 +210,7 @@ public class AzureCostApiRetriever : ICostRetriever
 
             var currency = row[3].ToString();
 
-            var costItem = new CostItem(date, value, valueUsd, currency);
+            var costItem = new CostItem(date, value, valueUsd, currency, "");
             items.Add(costItem);
         }
 
@@ -222,7 +222,7 @@ public class AzureCostApiRetriever : ICostRetriever
     public async Task<IEnumerable<CostNamedItem>> RetrieveCostByServiceName(bool includeDebugOutput,
         Scope scope, string[] filter, MetricType metric, TimeframeType timeFrame, DateOnly from, DateOnly to)
     {        
-        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2021-10-01&$top=5000");
+        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
         
         var payload = new
         {
@@ -294,7 +294,7 @@ public class AzureCostApiRetriever : ICostRetriever
         string[] filter,MetricType metric,
         TimeframeType timeFrame, DateOnly from, DateOnly to)
     {
-        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2021-10-01&$top=5000");
+        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
         var payload = new
         {
@@ -366,7 +366,7 @@ public class AzureCostApiRetriever : ICostRetriever
         Scope scope, string[] filter,MetricType metric,
         TimeframeType timeFrame, DateOnly from, DateOnly to)
     {
-        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2021-10-01&$top=5000");
+        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
         var payload = new
         {
@@ -443,7 +443,7 @@ public class AzureCostApiRetriever : ICostRetriever
        Scope scope, string[] filter, MetricType metric,
         TimeframeType timeFrame, DateOnly from, DateOnly to)
     {
-        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2021-10-01&$top=5000");
+        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
         
         var payload = new
         {
@@ -518,10 +518,9 @@ public class AzureCostApiRetriever : ICostRetriever
 
     public async Task<IEnumerable<CostDailyItem>> RetrieveDailyCost(bool includeDebugOutput,
         Scope scope, string[] filter, MetricType metric, string dimension,
-        TimeframeType timeFrame, DateOnly from, DateOnly to)
+        TimeframeType timeFrame, DateOnly from, DateOnly to, bool includeTags)
     {
-        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2021-10-01&$top=5000");
-
+        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
         var payload = new
         {
@@ -537,6 +536,7 @@ public class AzureCostApiRetriever : ICostRetriever
             dataSet = new
             {
                 granularity = "Daily",
+                include = includeTags ? new[] { "Tags" } : null,
                 aggregation = new
                 {
                     totalCost = new
@@ -587,9 +587,20 @@ public class AzureCostApiRetriever : ICostRetriever
             var value = double.Parse(row[0].ToString(), CultureInfo.InvariantCulture);
             var valueUsd = double.Parse(row[1].ToString(), CultureInfo.InvariantCulture);
 
+            // if includeTags is true, row[5] is the tag, and row[6] is the currency, otherwise row[5] is the currency
             var currency = row[5].ToString();
+            var tags = "";
 
-            var costItem = new CostDailyItem(date, resourceGroupName, value, valueUsd, currency);
+            // if includeTags is true, switch the value between currency and tags
+            // that's the order how the API REST exposes the resultset
+            if (includeTags)
+            {
+                System.Text.Json.JsonElement element = row[5];
+                tags = element.GetRawText();
+                currency = row[6].ToString();
+            }
+
+            var costItem = new CostDailyItem(date, resourceGroupName, value, valueUsd, currency, tags);
             items.Add(costItem);
         }
 
@@ -674,7 +685,7 @@ public class AzureCostApiRetriever : ICostRetriever
 
                 var currency = row[3].ToString();
 
-                var costItem = new CostItem(date, value, value, currency);
+                var costItem = new CostItem(date, value, value, currency, "");
                 items.Add(costItem);
             }
         }
@@ -696,7 +707,7 @@ public class AzureCostApiRetriever : ICostRetriever
         DateOnly from,
         DateOnly to)
     {
-        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2021-10-01&$top=5000");
+        var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
         object grouping;
         if (excludeMeterDetails == false)

--- a/src/CostApi/CostDailyItem.cs
+++ b/src/CostApi/CostDailyItem.cs
@@ -1,3 +1,4 @@
 namespace AzureCostCli.CostApi;
 
-public record CostDailyItem(DateOnly Date, string Name, double Cost, double CostUsd, string Currency);
+public record CostDailyItem(DateOnly Date, string Name, double Cost, double CostUsd, string Currency, string Tags);
+public record CostDailyItemWithoutTags(DateOnly Date, string Name, double Cost, double CostUsd, string Currency);

--- a/src/CostApi/CostItem.cs
+++ b/src/CostApi/CostItem.cs
@@ -1,3 +1,3 @@
 namespace AzureCostCli.CostApi;
 
-public record CostItem(DateOnly Date, double Cost, double CostUsd, string Currency);
+public record CostItem(DateOnly Date, double Cost, double CostUsd, string Currency, string Tags);

--- a/src/CostApi/ICostRetriever.cs
+++ b/src/CostApi/ICostRetriever.cs
@@ -35,7 +35,7 @@ public interface ICostRetriever
     Task<IEnumerable<UsageDetails>> RetrieveUsageDetails(bool includeDebugOutput,
         Scope scope, string filter, DateOnly from,        DateOnly to);
     
-    Task<IEnumerable<CostDailyItem>> RetrieveDailyCost(bool settingsDebug, Scope scope, string[] filter,MetricType metric, string dimension, TimeframeType settingsTimeframe, DateOnly settingsFrom, DateOnly settingsTo);
+    Task<IEnumerable<CostDailyItem>> RetrieveDailyCost(bool settingsDebug, Scope scope, string[] filter,MetricType metric, string dimension, TimeframeType settingsTimeframe, DateOnly settingsFrom, DateOnly settingsTo, bool includeTags);
 }
 
 

--- a/src/OutputFormatters/CsvOutputFormatter.cs
+++ b/src/OutputFormatters/CsvOutputFormatter.cs
@@ -34,7 +34,28 @@ public class CsvOutputFormatter : BaseOutputFormatter
 
     public override Task WriteDailyCost(DailyCostSettings settings, IEnumerable<CostDailyItem> dailyCosts)
     {
-        return ExportToCsv(settings.SkipHeader, dailyCosts);
+        // code to create the column Tags only when needed
+        // small trick with the records dailyCostItemWithoutTags, and dailyCostItem
+        if (settings.IncludeTags == false)
+        {
+            var dailyCostsWithoutTags = new List<CostDailyItemWithoutTags>();
+            foreach (var item in dailyCosts)
+            {
+                var newItem = new CostDailyItemWithoutTags(
+                    Name: item.Name,
+                    Date: item.Date,
+                    Cost: item.Cost,
+                    Currency: item.Currency,
+                    CostUsd: item.CostUsd
+                );
+                dailyCostsWithoutTags.Add(newItem);
+            }
+            return ExportToCsv(settings.SkipHeader, dailyCostsWithoutTags); 
+        }
+        else 
+        {
+            return ExportToCsv(settings.SkipHeader, dailyCosts);
+        }
     }
 
     public override Task WriteAnomalyDetectionResults(DetectAnomalySettings settings, List<AnomalyDetectionResult> anomalies)

--- a/src/OutputFormatters/JsonOutputFormatter.cs
+++ b/src/OutputFormatters/JsonOutputFormatter.cs
@@ -65,16 +65,29 @@ public class JsonOutputFormatter : BaseOutputFormatter
     public override Task WriteDailyCost(DailyCostSettings settings, IEnumerable<CostDailyItem> dailyCosts)
     {
         // Create a new variable to hold the dailyCost items per day
-        var output = dailyCosts
+        // Code to avoid creating the column Tags when is not needed
+        if (settings.IncludeTags == false)
+        {
+            var output = dailyCosts
+                        .GroupBy(a => a.Date)
+                        .Select(a => new
+                        {
+                            Date = a.Key,
+                            Items = a.Select(b => new { b.Name, b.Cost, b.Currency, b.CostUsd})
+                        });
+            WriteJson(settings, output);
+        }
+        else
+        {
+            var output = dailyCosts
             .GroupBy(a => a.Date)
             .Select(a => new
-        {
-            Date = a.Key,
-            Items = a.Select(b => new { b.Name, b.Cost, b.Currency, b.CostUsd })
-        });
-
-        WriteJson(settings, output);
-
+            {
+                Date = a.Key,
+                Items = a.Select(b => new { b.Name, b.Cost, b.Currency, b.CostUsd, b.Tags})
+            });
+            WriteJson(settings, output);
+        }
         return Task.CompletedTask;
     }
 

--- a/src/OutputFormatters/MarkdownOutputFormatter.cs
+++ b/src/OutputFormatters/MarkdownOutputFormatter.cs
@@ -301,7 +301,7 @@ public class MarkdownOutputFormatter : BaseOutputFormatter
             var othersCost = day.Except(topCosts)
                 .Sum(item => settings.UseUSD ? item.CostUsd : item.Cost);
 
-            topCosts.Add(new CostDailyItem(day.Key, "Other", othersCost, othersCost, day.First().Currency));
+            topCosts.Add(new CostDailyItem(day.Key, "Other", othersCost, othersCost, day.First().Currency, ""));
 
             var dailyCost = 0D; // Keep track of the total cost for this day
             var breakdown = new List<string>();

--- a/src/OutputFormatters/TextOutputFormatter.cs
+++ b/src/OutputFormatters/TextOutputFormatter.cs
@@ -178,7 +178,7 @@ public class TextOutputFormatter : BaseOutputFormatter
             var othersCost = day.Except(topCosts)
                 .Sum(item => settings.UseUSD ? item.CostUsd : item.Cost);
 
-            topCosts.Add(new CostDailyItem(day.Key, "Other", othersCost, othersCost, day.First().Currency));
+            topCosts.Add(new CostDailyItem(day.Key, "Other", othersCost, othersCost, day.First().Currency, ""));
 
             Console.Write($"{day.Key.ToString(CultureInfo.CurrentCulture)}  ");
 


### PR DESCRIPTION
Hello @mivano 

I need to export the daily costs data by resourceId and include into the resultset the resource Tags.
It is useful for scenarios where data is exported to analyze using Power BI.

I have changed the code to support exporting Tags when:
- Output format is json, jsonc, and csv.
- Report type is DailyCost.

I have chaged the API version to 2023-03-01.

This is the logic of the new option:
- if --includeTags is added into the call, a new column called Tags will include the tags for the dimension.
- The new column type is Json.
- To avoid breaking things: if the request is not DailyCost, is not Json, is not JsonC, and is not Csv, the includeTags variable is set to false.

I had to add a new record called CostDailyItemWithoutTags where rows were moved when includeTags is False.
It was a small switch in the Csv Output formaters depending on the setgings:

![image](https://github.com/mivano/azure-cost-cli/assets/7208487/595db94f-acc3-4a91-90f2-ff992753018f)

For the Json formater was easier:

![image](https://github.com/mivano/azure-cost-cli/assets/7208487/fb42435a-6461-4ef2-8bf8-6920d815a342)


I have edited the readme.md to include usage description.

I am happy you consider adding this option to the main brach!

Regards,
Eladio

