### PR TITLE
Fix HttpClient BaseAddress setting

### DIFF
--- a/src/CostApi/AzureCostApiRetriever.cs
+++ b/src/CostApi/AzureCostApiRetriever.cs
@@ -126,9 +126,12 @@ public class AzureCostApiRetriever : ICostRetriever
             AnsiConsole.Write(new JsonText(JsonSerializer.Serialize(payload)));
             AnsiConsole.WriteLine();
         }
-        
-        _client.BaseAddress = new Uri(CostApiAddress);
-        
+
+        if (!string.Equals(_client.BaseAddress?.ToString(), CostApiAddress))
+        {
+            _client.BaseAddress = new Uri(CostApiAddress);
+        }
+
         var options = new JsonSerializerOptions
         {
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,

--- a/src/CostApi/AzurePriceRetriever.cs
+++ b/src/CostApi/AzurePriceRetriever.cs
@@ -18,7 +18,7 @@ public class AzurePriceRetriever : IPriceRetriever
         _client.BaseAddress = new Uri(PriceApiAddress);
         
         var prices = new List<PriceRecord>();
-        string? url = "https://prices.azure.com/api/retail/prices?api-version=2023-01-01-preview&currencyCode='" + currencyCode + "'";
+        string? url = "api/retail/prices?api-version=2023-01-01-preview&currencyCode='" + currencyCode + "'";
 
         // Append the filter to the URL if it's provided
         if (!string.IsNullOrWhiteSpace(filter))

--- a/src/CostApi/AzurePriceRetriever.cs
+++ b/src/CostApi/AzurePriceRetriever.cs
@@ -15,8 +15,11 @@ public class AzurePriceRetriever : IPriceRetriever
 
     public async Task<IEnumerable<PriceRecord>> GetAzurePricesAsync(string currencyCode = "USD", string? filter = null)
     {
-        _client.BaseAddress = new Uri(PriceApiAddress);
-        
+        if (!string.Equals(_client.BaseAddress?.ToString(), PriceApiAddress))
+        {
+            _client.BaseAddress = new Uri(PriceApiAddress);
+        }
+
         var prices = new List<PriceRecord>();
         string? url = "api/retail/prices?api-version=2023-01-01-preview&currencyCode='" + currencyCode + "'";
 


### PR DESCRIPTION
When executing `azure-cost` with default command `accumulatedCost`, I encountered the following error message: _"This instance has already started one or more requests. Properties can only be modified before sending the first request."_

The PR #122 added the ability to select CostApi and PriceApi base URL which seems to broke at least `accumulatedCost` command. This is caused by setting the BaseAddress property of a HttpClient that has already made a request before. The `accumulatedCost` command uses the same instance of `ICostRetriever` to make multiple HTTP requests, and when making the second call, the error above occurs. 

To overcome this issue, the BaseAddress should be set for the HttpClient only if it differs from the default value, which will ideally not change throughout its lifecycle.

I also removed the hardcoded PriceApi address that is probably a leftover, and use the default or the one set through CLI args.