### PR TITLE
Updated RetrieveDailyCost method to handle pagination. Uses nextLink from API response.

### DIFF
--- a/src/CostApi/CostQueryResponse.cs
+++ b/src/CostApi/CostQueryResponse.cs
@@ -21,6 +21,6 @@ public class Columns
 public class Properties
 {
     public Columns[] columns { get; set; }
-    public object nextLink { get; set; }
+    public string nextLink { get; set; }
     public JsonElement[] rows { get; set; }
 }


### PR DESCRIPTION
I was using the daily cost component with --dimension ResourceId and noticed that it can handle max 5000 rows as this is the max for a single API call.

For this single method I have added support for obtaining the full dataset by following the nextlink returned in the response until empty\null.

I find this useful, as combined with the time frame function my results are often more than 5000 rows.

Please let me know what you think and if you want I can add the same logic to the other calls.

Thank you for this great tool!