### PR TITLE
remove hardcoded timeframe that limits detect anomaly to last 30 day…

### DIFF
--- a/src/Commands/DetectAnomaly/DetectAnomaly.cs
+++ b/src/Commands/DetectAnomaly/DetectAnomaly.cs
@@ -84,12 +84,6 @@ public class DetectAnomalyCommand : AsyncCommand<DetectAnomalySettings>
             }
         }
 
-        // Change the settings so it uses a custom timeframe and fetch the last 30 days of data, not including today
-
-        settings.Timeframe = TimeframeType.Custom;
-        settings.From = DateOnly.FromDateTime(DateTime.Today.AddDays(-30));
-        settings.To = DateOnly.FromDateTime(DateTime.Today.AddDays(-1));
-
         // Fetch the costs from the Azure Cost Management API
         var dailyCost = await _costRetriever.RetrieveDailyCost(settings.Debug, settings.GetScope,
             settings.Filter,


### PR DESCRIPTION
Not sure if intentional or not, but detect anomaly was hard coded to use last 30days only.
I removed this and tested and now allows use of custom time frame passed in.
Appears to work ok with nothing passed in - uses current billing month I think.

Please let me know if I missed something.

Thanks!