### PR TITLE
Added ability to change http timeout via command line for cost retrieval

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/src/Commands/Budgets/BudgetsCommand.cs
+++ b/src/Commands/Budgets/BudgetsCommand.cs
@@ -7,7 +7,7 @@ using Spectre.Console.Cli;
 
 namespace AzureCostCli.Commands.Budgets;
 
-public class BudgetsCommand: AsyncCommand<BudgetsSettings>
+public class BudgetsCommand : AsyncCommand<BudgetsSettings>
 {
     private readonly ICostRetriever _costRetriever;
 
@@ -16,7 +16,7 @@ public class BudgetsCommand: AsyncCommand<BudgetsSettings>
     public BudgetsCommand(ICostRetriever costRetriever)
     {
         _costRetriever = costRetriever;
-        
+
         // Add the output formatters
         _outputFormatters.Add(OutputFormat.Console, new ConsoleOutputFormatter());
         _outputFormatters.Add(OutputFormat.Json, new JsonOutputFormatter());
@@ -31,9 +31,10 @@ public class BudgetsCommand: AsyncCommand<BudgetsSettings>
         // Show version
         if (settings.Debug)
             AnsiConsole.WriteLine($"Version: {typeof(CostByResourceCommand).Assembly.GetName().Version}");
-        
+
         _costRetriever.CostApiAddress = settings.CostApiAddress;
-        
+        _costRetriever.HttpTimeout = TimeSpan.FromSeconds(settings.HttpTimeout);
+
         // Get the subscription ID from the settings
         var subscriptionId = settings.Subscription;
 
@@ -44,12 +45,12 @@ public class BudgetsCommand: AsyncCommand<BudgetsSettings>
             {
                 if (settings.Debug)
                     AnsiConsole.WriteLine("No subscription ID specified. Trying to retrieve the default subscription ID from Azure CLI.");
-                
+
                 subscriptionId = Guid.Parse(AzCommand.GetDefaultAzureSubscriptionId());
-                
+
                 if (settings.Debug)
                     AnsiConsole.WriteLine($"Default subscription ID retrieved from az cli: {subscriptionId}");
-                
+
                 settings.Subscription = subscriptionId;
             }
             catch (Exception e)
@@ -69,6 +70,6 @@ public class BudgetsCommand: AsyncCommand<BudgetsSettings>
 
         return 0;
     }
-    
-    
+
+
 }

--- a/src/Commands/CostByResource/CostByResourceCommand.cs
+++ b/src/Commands/CostByResource/CostByResourceCommand.cs
@@ -58,7 +58,8 @@ public class CostByResourceCommand : AsyncCommand<CostByResourceSettings>
             AnsiConsole.WriteLine($"Version: {typeof(CostByResourceCommand).Assembly.GetName().Version}");
 
         _costRetriever.CostApiAddress = settings.CostApiAddress;
-        
+        _costRetriever.HttpTimeout = TimeSpan.FromSeconds(settings.HttpTimeout);
+
         // Get the subscription ID from the settings
         var subscriptionId = settings.Subscription;
 

--- a/src/Commands/CostByTag/CostByTagCommand.cs
+++ b/src/Commands/CostByTag/CostByTagCommand.cs
@@ -57,7 +57,8 @@ public class CostByTagCommand : AsyncCommand<CostByTagSettings>
             AnsiConsole.WriteLine($"Version: {typeof(CostByResourceCommand).Assembly.GetName().Version}");
 
         _costRetriever.CostApiAddress = settings.CostApiAddress;
-        
+        _costRetriever.HttpTimeout = TimeSpan.FromSeconds(settings.HttpTimeout);
+
         // Get the subscription ID from the settings
         var subscriptionId = settings.Subscription;
 

--- a/src/Commands/CostSettings.cs
+++ b/src/Commands/CostSettings.cs
@@ -84,7 +84,10 @@ public class CostSettings : LogCommandSettings, ICostSettings
     [CommandOption("--priceApiBaseAddress <BASE_ADDRESS>")]
     [Description("The base address for the Price API. Defaults to https://prices.azure.com/")]
     public string PriceApiAddress { get; set; } = "https://prices.azure.com/";
-
+    
+    [CommandOption("--httpTimeout <TIMEOUT>")]
+    [Description("Allows overriding the default HTTP timeout in seconds. Defaults to 100 seconds.")]
+    public int HttpTimeout { get; set; } = 100;
     
     public Scope GetScope
     {

--- a/src/Commands/DailyCost/DailyCost.cs
+++ b/src/Commands/DailyCost/DailyCost.cs
@@ -59,7 +59,8 @@ public class DailyCostCommand : AsyncCommand<DailyCostSettings>
 
 
         _costRetriever.CostApiAddress = settings.CostApiAddress;
-        
+        _costRetriever.HttpTimeout = TimeSpan.FromSeconds(settings.HttpTimeout);
+
         // Get the subscription ID from the settings
         var subscriptionId = settings.Subscription;
 
@@ -90,7 +91,7 @@ public class DailyCostCommand : AsyncCommand<DailyCostSettings>
         IEnumerable<CostDailyItem> dailyCost = new List<CostDailyItem>();
 
         // if output format is not csv, json, or jsonc, then don't include tags
-        if (settings.Output != OutputFormat.Json && 
+        if (settings.Output != OutputFormat.Json &&
             settings.Output != OutputFormat.Jsonc &&
             settings.Output != OutputFormat.Csv)
         {

--- a/src/Commands/DetectAnomaly/DetectAnomaly.cs
+++ b/src/Commands/DetectAnomaly/DetectAnomaly.cs
@@ -56,6 +56,7 @@ public class DetectAnomalyCommand : AsyncCommand<DetectAnomalySettings>
         if (settings.Debug)
             AnsiConsole.WriteLine($"Version: {typeof(AccumulatedCostCommand).Assembly.GetName().Version}");
         _costRetriever.CostApiAddress = settings.CostApiAddress;
+        _costRetriever.HttpTimeout = TimeSpan.FromSeconds(settings.HttpTimeout);
 
         // Get the subscription ID from the settings
         var subscriptionId = settings.Subscription;

--- a/src/CostApi/ICostRetriever.cs
+++ b/src/CostApi/ICostRetriever.cs
@@ -4,9 +4,9 @@ namespace AzureCostCli.CostApi;
 
 public interface ICostRetriever
 {
-
     public string CostApiAddress { get; set; }
-    
+    public TimeSpan HttpTimeout { get; set; }
+
     Task<Subscription> RetrieveSubscription(bool includeDebugOutput, Guid subscriptionId);
     
     Task<IEnumerable<CostItem>> RetrieveCosts(bool includeDebugOutput, Scope scope,
@@ -36,10 +36,7 @@ public interface ICostRetriever
     Task<IEnumerable<BudgetItem>> RetrieveBudgets(bool settingsDebug, Scope scope);
 
     Task<IEnumerable<UsageDetails>> RetrieveUsageDetails(bool includeDebugOutput,
-        Scope scope, string filter, DateOnly from,        DateOnly to);
+        Scope scope, string filter, DateOnly from, DateOnly to);
     
     Task<IEnumerable<CostDailyItem>> RetrieveDailyCost(bool settingsDebug, Scope scope, string[] filter,MetricType metric, string dimension, TimeframeType settingsTimeframe, DateOnly settingsFrom, DateOnly settingsTo, bool includeTags);
 }
-
-
-


### PR DESCRIPTION
When I use the cli to retrieve big cost datasets from azure, I sometimes run into the default .net core http client timeout settings (100 seconds). This PR adds the option to override the timeout through a command line argument. Only supported for calls to the cost api.

Due to my vscode settings there are some formatting / whitespace changes as well, apologies.