### PR TITLE
Add total cost in timeframe to output formatters

### DIFF
--- a/src/OutputFormatters/ConsoleOutputFormatter.cs
+++ b/src/OutputFormatters/ConsoleOutputFormatter.cs
@@ -51,6 +51,8 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
         var costLastThirtyDays = accumulatedCostDetails.Costs.Where(x => x.Date >= todaysDate.AddDays(-30))
             .Sum(a => settings.UseUSD ? a.CostUsd : a.Cost);
 
+        var totalCostInTimeframe = accumulatedCostDetails.Costs.Sum(a => settings.UseUSD ? a.CostUsd : a.Cost);
+
         var currency = settings.UseUSD ? "USD" : accumulatedCostDetails.Costs.FirstOrDefault()?.Currency;
 
         // Header
@@ -84,6 +86,7 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
             new Money(costSinceStartOfCurrentMonth, currency));
         table.AddRow(new Markup("[yellow bold]Last 7 days:[/]"), new Money(costLastSevenDays, currency));
         table.AddRow(new Markup("[yellow bold]Last 30 days:[/]"), new Money(costLastThirtyDays, currency));
+        table.AddRow(new Markup("[yellow bold]Total in timeframe:[/]"), new Money(totalCostInTimeframe, currency));
 
         var accumulatedCostChart = new BarChart()
             .Width(60)

--- a/src/OutputFormatters/JsonOutputFormatter.cs
+++ b/src/OutputFormatters/JsonOutputFormatter.cs
@@ -31,6 +31,7 @@ public class JsonOutputFormatter : BaseOutputFormatter
                     .Sum(a => settings.UseUSD ? a.CostUsd :  a.Cost),
                 lastThirtyDaysCost = accumulatedCostDetails.Costs.Where(a => a.Date >= DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-30)))
                     .Sum(a => settings.UseUSD ? a.CostUsd :  a.Cost),
+                totalCostInTimeframe = accumulatedCostDetails.Costs.Sum(a => settings.UseUSD ? a.CostUsd : a.Cost)
             },
             cost = accumulatedCostDetails.Costs.OrderBy(a => a.Date).Select(a => new { a.Date, a.Cost, a.Currency, a.CostUsd }),
             forecastedCosts = accumulatedCostDetails.ForecastedCosts.OrderByDescending(a => a.Date)

--- a/src/OutputFormatters/MarkdownOutputFormatter.cs
+++ b/src/OutputFormatters/MarkdownOutputFormatter.cs
@@ -28,6 +28,7 @@ public class MarkdownOutputFormatter : BaseOutputFormatter
                     .Sum(a => settings.UseUSD ? a.CostUsd :a.Cost),
                 lastThirtyDaysCost = accumulatedCostDetails.Costs.Where(a => a.Date >= DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-30)))
                     .Sum(a => settings.UseUSD ? a.CostUsd :a.Cost),
+                totalCostInTimeframe = accumulatedCostDetails.Costs.Sum(a => settings.UseUSD ? a.CostUsd : a.Cost)
             },
         };
 
@@ -47,6 +48,7 @@ public class MarkdownOutputFormatter : BaseOutputFormatter
         Console.WriteLine($"|Yesterday|{output.costs.yesterdayCost:N2} {currency}|");
         Console.WriteLine($"|Last 7 days|{output.costs.lastSevenDaysCost:N2} {currency}|");
         Console.WriteLine($"|Last 30 days|{output.costs.lastThirtyDaysCost:N2} {currency}|");
+        Console.WriteLine($"|Total cost in timeframe|{output.costs.totalCostInTimeframe:N2} {currency}|");
 
         // Generate a gantt chart using mermaidjs
         Console.WriteLine();

--- a/src/OutputFormatters/TextOutputFormatter.cs
+++ b/src/OutputFormatters/TextOutputFormatter.cs
@@ -27,6 +27,7 @@ public class TextOutputFormatter : BaseOutputFormatter
                     .Sum(a => settings.UseUSD ? a.CostUsd :  a.Cost),
                 lastThirtyDaysCost = accumulatedCostDetails.Costs.Where(a => a.Date >= DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-30)))
                     .Sum(a => settings.UseUSD ? a.CostUsd :  a.Cost),
+                totalCostInTimeframe = accumulatedCostDetails.Costs.Sum(a => settings.UseUSD ? a.CostUsd : a.Cost)
             },
         };
 
@@ -40,7 +41,8 @@ public class TextOutputFormatter : BaseOutputFormatter
         Console.WriteLine($"  Yesterday: {output.costs.yesterdayCost:N2} {currency}");
         Console.WriteLine($"  Last 7 days: {output.costs.lastSevenDaysCost:N2} {currency}");
         Console.WriteLine($"  Last 30 days: {output.costs.lastThirtyDaysCost:N2} {currency}");
-        
+        Console.WriteLine($"  Total cost in timeframe: {output.costs.totalCostInTimeframe:N2} {currency}");
+
         Console.WriteLine();
         Console.WriteLine("By Service Name:");
         foreach (var cost in accumulatedCostDetails.ByServiceNameCosts.TrimList(threshold: settings.OthersCutoff))


### PR DESCRIPTION
When setting a custom timeframe, the accumulated outputs have no stable output for the total cost in that timeframe. This PR adds this. 