### PR TITLE
Fix billing scope output for MCA

### DIFF
--- a/src/Commands/AccumulatedCost/AccumulatedCostCommand.cs
+++ b/src/Commands/AccumulatedCost/AccumulatedCostCommand.cs
@@ -100,9 +100,13 @@ public class AccumulatedCostCommand : AsyncCommand<AccumulatedCostSettings>
                 }
                 else
                 {
-                    ctx.Status = "Fetching Enrollment details...";
+                    ctx.Status = $"Fetching {settings.GetScope.Name} details...";
+
                     // Fetch the enrollment details //TODO
-                    subscription = new Subscription(string.Empty, string.Empty, Array.Empty<object>(), "Enrollment", "Enrollment", $"Enrollment {settings.EnrollmentAccountId}", "Active", new SubscriptionPolicies(string.Empty, string.Empty, string.Empty));
+
+                    var enrollmentIdDisplayName = settings.EnrollmentAccountId != null ? $" {settings.EnrollmentAccountId}" : "";
+                    var billingIdDisplayName = settings.BillingAccountId != null ? $" {settings.BillingAccountId}" : "";
+                    subscription = new Subscription(string.Empty, string.Empty, Array.Empty<object>(), settings.GetScope.Name, settings.GetScope.Name, $"{settings.GetScope.Name} {enrollmentIdDisplayName} {billingIdDisplayName}", "Active", new SubscriptionPolicies(string.Empty, string.Empty, string.Empty));
                 }
 
                 ctx.Status = "Fetching cost data...";

--- a/src/OutputFormatters/ConsoleOutputFormatter.cs
+++ b/src/OutputFormatters/ConsoleOutputFormatter.cs
@@ -130,8 +130,9 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
                 Color.FromInt32(counter++));
         }
 
-        // Render the resource groups table
+        // Render the resource groups or subscriptions table depending on scope
         BreakdownChartExt? resourceGroupBreakdown = null;
+        BreakdownChartExt? subscriptionBreakdown = null;
         if (settings.GetScope.IsSubscriptionBased)
         {
             resourceGroupBreakdown = new BreakdownChartExt()
@@ -145,14 +146,11 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
                     Color.FromInt32(counter++));
             }
         }
-
-        BreakdownChartExt? subscriptionBreakdown = null;
-        if (settings.GetScope.Name.Equals("EnrollmentAccount", StringComparison.InvariantCultureIgnoreCase))
+        else // not subscription based scope, so we don't render resource groups, we render subscription breakdown
         {
-            // Render the resource groups table
             subscriptionBreakdown = new BreakdownChartExt()
-            .UseValueFormatter(value => Money.FormatMoney(value, currency))
-            .Width(60);
+                .UseValueFormatter(value => Money.FormatMoney(value, currency))
+                .Width(60);
 
             counter = 2;
             foreach (var rg in accumulatedCostDetails.BySubscriptionCosts.TrimList(threshold: settings.OthersCutoff))
@@ -161,6 +159,7 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
                     Color.FromInt32(counter++));
             }
         }
+
 
         // Render the locations table
         var locationsBreakdown = new BreakdownChartExt()


### PR DESCRIPTION
Refer #195 
Changes to get MCS working for --billing-profile

Would be good for someone with an Enrollment ID to test this works for them as well - it should.

Apply subscription breakdown to all non-subscription scopes, not just EnrollmentAccount
- Fixes missing cost breakdown output when using --billing-scope
- Future-proofs against new non-subscription scope types

Update Accumulated Cost Command to handle enrollmentid and\or billingid