### PR TITLE
extend AccumulatedCostSettings and remove NET6_0-specific code

### DIFF
--- a/src/OutputFormatters/JsonOutputFormatter.cs
+++ b/src/OutputFormatters/JsonOutputFormatter.cs
@@ -186,17 +186,13 @@ public override Task WriteAccumulatedDiffCost(DiffSettings settings, Accumulated
         null
     );
 
-    return WriteAccumulatedCost(new AccumulatedCostSettings{ UseUSD = settings.UseUSD}, diffResult);
+    return WriteAccumulatedCost(new AccumulatedCostSettings{ UseUSD = settings.UseUSD, Output = settings.Output}, diffResult);
 }
 
     private static void WriteJson(ICostSettings settings, object items)
     {
 
         var options = new JsonSerializerOptions { WriteIndented = true };
-        
-#if NET6_0
-        options.Converters.Add(new DateOnlyJsonConverter());
-#endif
         
         var json = JsonSerializer.Serialize(items, options );
 


### PR DESCRIPTION
This pull request makes a small update to the cost output logic in the `JsonOutputFormatter`. The change ensures that the `Output` property from `DiffSettings` is now passed to `AccumulatedCostSettings` when writing accumulated cost results.

* Passing `settings.Output` to `AccumulatedCostSettings` in the `WriteAccumulatedDiffCost` method to ensure output formatting options are respected.