### PR TITLE
Show untagged resources in costByTag command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,12 @@ This will retrieve the cost of the subscription by the provided tag key(s). So i
 azure-cost costByTag  --tag cost-center --tag creator
 ```
 
+By default, resources without the specified tag(s) are included in an `(untagged)` group, making it easy to see what percentage of spend is properly tagged. To exclude untagged resources (the old behavior), use `--include-untagged false`:
+
+```bash
+azure-cost costByTag --tag cost-center --include-untagged false
+```
+
 The csv, json(c) and console output will render the results, either hierarchically or flattened in the case of the csv export.
 
 If you require more formatters, let me know!

--- a/src/Commands/CostByTag/CostByTagCommand.cs
+++ b/src/Commands/CostByTag/CostByTagCommand.cs
@@ -71,12 +71,12 @@ public class CostByTagCommand : AsyncCommand<CostByTagSettings>
 
         foreach (var resource in resources)
         {
+            var resourceTags = resource.Tags != null
+                ? new Dictionary<string, string>(resource.Tags, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
             foreach (var tag in tags)
             {
-                var resourceTags = resource.Tags != null
-                    ? new Dictionary<string, string>(resource.Tags, StringComparer.OrdinalIgnoreCase)
-                    : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
                 if (resourceTags.TryGetValue(tag, out var tagValue))
                 {
                     if (!resourcesByTag[tag].ContainsKey(tagValue))

--- a/src/Commands/CostByTag/CostByTagCommand.cs
+++ b/src/Commands/CostByTag/CostByTagCommand.cs
@@ -47,7 +47,7 @@ public class CostByTagCommand : AsyncCommand<CostByTagSettings>
                     settings.GetToDate());
             });
 
-        var byTags = GetResourcesByTag(resources, settings.Tags.ToArray());
+        var byTags = GetResourcesByTag(resources, settings.IncludeUntagged, settings.Tags.ToArray());
 
         // Write the output
         await _outputFormatters[settings.Output]
@@ -56,9 +56,11 @@ public class CostByTagCommand : AsyncCommand<CostByTagSettings>
         return 0;
     }
 
-    private Dictionary<string, Dictionary<string, List<CostResourceItem>>> GetResourcesByTag(
-        IEnumerable<CostResourceItem> resources, params string[] tags)
+    public static Dictionary<string, Dictionary<string, List<CostResourceItem>>> GetResourcesByTag(
+        IEnumerable<CostResourceItem> resources, bool includeUntagged, params string[] tags)
     {
+        const string untaggedGroup = "(untagged)";
+
         var resourcesByTag =
             new Dictionary<string, Dictionary<string, List<CostResourceItem>>>(StringComparer.OrdinalIgnoreCase);
 
@@ -71,7 +73,9 @@ public class CostByTagCommand : AsyncCommand<CostByTagSettings>
         {
             foreach (var tag in tags)
             {
-                var resourceTags = new Dictionary<string, string>(resource.Tags, StringComparer.OrdinalIgnoreCase);
+                var resourceTags = resource.Tags != null
+                    ? new Dictionary<string, string>(resource.Tags, StringComparer.OrdinalIgnoreCase)
+                    : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
                 if (resourceTags.TryGetValue(tag, out var tagValue))
                 {
@@ -81,6 +85,15 @@ public class CostByTagCommand : AsyncCommand<CostByTagSettings>
                     }
 
                     resourcesByTag[tag][tagValue].Add(resource);
+                }
+                else if (includeUntagged)
+                {
+                    if (!resourcesByTag[tag].ContainsKey(untaggedGroup))
+                    {
+                        resourcesByTag[tag][untaggedGroup] = new List<CostResourceItem>();
+                    }
+
+                    resourcesByTag[tag][untaggedGroup].Add(resource);
                 }
             }
         }

--- a/src/Commands/CostByTag/CostByTagSettings.cs
+++ b/src/Commands/CostByTag/CostByTagSettings.cs
@@ -10,7 +10,8 @@ public class CostByTagSettings : CostSettings
     [Description("The tags to return, for example: Cost Center or Owner. You can specify multiple tags by using the --tag option multiple times.")]
     public string[] Tags { get; set; } = Array.Empty<string>();
 
-    [CommandOption("--include-untagged")]
+    [CommandOption("--include-untagged <INCLUDE_UNTAGGED>")]
     [Description("Include resources without the specified tag(s) in an '(untagged)' group. Defaults to true.")]
+    [DefaultValue(true)]
     public bool IncludeUntagged { get; set; } = true;
 }

--- a/src/Commands/CostByTag/CostByTagSettings.cs
+++ b/src/Commands/CostByTag/CostByTagSettings.cs
@@ -9,4 +9,8 @@ public class CostByTagSettings : CostSettings
     [CommandOption("--tag")]
     [Description("The tags to return, for example: Cost Center or Owner. You can specify multiple tags by using the --tag option multiple times.")]
     public string[] Tags { get; set; } = Array.Empty<string>();
+
+    [CommandOption("--include-untagged")]
+    [Description("Include resources without the specified tag(s) in an '(untagged)' group. Defaults to true.")]
+    public bool IncludeUntagged { get; set; } = true;
 }

--- a/tests/AzureCostCli.Tests/Commands/CostByTagTests.cs
+++ b/tests/AzureCostCli.Tests/Commands/CostByTagTests.cs
@@ -21,7 +21,7 @@ public class CostByTagTests
             ServiceName: "Virtual Machines",
             ServiceTier: "Standard",
             Meter: "D2s v3",
-            Tags: tags ?? new Dictionary<string, string>(),
+            Tags: tags!,
             Currency: "USD");
     }
 

--- a/tests/AzureCostCli.Tests/Commands/CostByTagTests.cs
+++ b/tests/AzureCostCli.Tests/Commands/CostByTagTests.cs
@@ -1,0 +1,170 @@
+using AzureCostCli.Commands.CostByTag;
+using AzureCostCli.CostApi;
+using Shouldly;
+using Xunit;
+
+namespace AzureCostCli.Tests.Commands;
+
+public class CostByTagTests
+{
+    private static CostResourceItem CreateResource(double cost, Dictionary<string, string>? tags = null)
+    {
+        return new CostResourceItem(
+            Cost: cost,
+            CostUSD: cost,
+            ResourceId: "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1",
+            ResourceType: "Microsoft.Compute/virtualMachines",
+            ResourceLocation: "eastus",
+            ChargeType: "Usage",
+            ResourceGroupName: "rg1",
+            PublisherType: "Azure",
+            ServiceName: "Virtual Machines",
+            ServiceTier: "Standard",
+            Meter: "D2s v3",
+            Tags: tags ?? new Dictionary<string, string>(),
+            Currency: "USD");
+    }
+
+    [Fact]
+    public void AllResourcesTagged_ReturnsNormalGrouping()
+    {
+        var resources = new[]
+        {
+            CreateResource(10, new Dictionary<string, string> { { "environment", "prod" } }),
+            CreateResource(20, new Dictionary<string, string> { { "environment", "dev" } }),
+        };
+
+        var result = CostByTagCommand.GetResourcesByTag(resources, includeUntagged: true, "environment");
+
+        result.ShouldContainKey("environment");
+        result["environment"].ShouldContainKey("prod");
+        result["environment"].ShouldContainKey("dev");
+        result["environment"].ShouldNotContainKey("(untagged)");
+        result["environment"]["prod"].Count.ShouldBe(1);
+        result["environment"]["dev"].Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ResourcesMissingTag_IncludeUntaggedTrue_AppearsInUntaggedGroup()
+    {
+        var resources = new[]
+        {
+            CreateResource(10, new Dictionary<string, string> { { "environment", "prod" } }),
+            CreateResource(20, new Dictionary<string, string> { { "owner", "alice" } }),
+        };
+
+        var result = CostByTagCommand.GetResourcesByTag(resources, includeUntagged: true, "environment");
+
+        result["environment"].ShouldContainKey("prod");
+        result["environment"].ShouldContainKey("(untagged)");
+        result["environment"]["(untagged)"].Count.ShouldBe(1);
+        result["environment"]["(untagged)"][0].Cost.ShouldBe(20);
+    }
+
+    [Fact]
+    public void ResourcesMissingTag_IncludeUntaggedFalse_ExcludesUntagged()
+    {
+        var resources = new[]
+        {
+            CreateResource(10, new Dictionary<string, string> { { "environment", "prod" } }),
+            CreateResource(20, new Dictionary<string, string> { { "owner", "alice" } }),
+        };
+
+        var result = CostByTagCommand.GetResourcesByTag(resources, includeUntagged: false, "environment");
+
+        result["environment"].ShouldContainKey("prod");
+        result["environment"].ShouldNotContainKey("(untagged)");
+        result["environment"].Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void EmptyTagsDictionary_IncludeUntaggedTrue_AppearsInUntaggedGroup()
+    {
+        var resources = new[]
+        {
+            CreateResource(15, new Dictionary<string, string>()),
+        };
+
+        var result = CostByTagCommand.GetResourcesByTag(resources, includeUntagged: true, "environment");
+
+        result["environment"].ShouldContainKey("(untagged)");
+        result["environment"]["(untagged)"].Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void NullTagsDictionary_IncludeUntaggedTrue_AppearsInUntaggedGroup()
+    {
+        var resources = new[]
+        {
+            CreateResource(15, null),
+        };
+
+        var result = CostByTagCommand.GetResourcesByTag(resources, includeUntagged: true, "environment");
+
+        result["environment"].ShouldContainKey("(untagged)");
+        result["environment"]["(untagged)"].Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void MixedResources_CorrectGrouping()
+    {
+        var resources = new[]
+        {
+            CreateResource(10, new Dictionary<string, string> { { "environment", "prod" } }),
+            CreateResource(20, new Dictionary<string, string> { { "environment", "dev" } }),
+            CreateResource(30, new Dictionary<string, string> { { "owner", "bob" } }),
+            CreateResource(40, new Dictionary<string, string>()),
+            CreateResource(50, null),
+        };
+
+        var result = CostByTagCommand.GetResourcesByTag(resources, includeUntagged: true, "environment");
+
+        result["environment"]["prod"].Count.ShouldBe(1);
+        result["environment"]["dev"].Count.ShouldBe(1);
+        result["environment"]["(untagged)"].Count.ShouldBe(3);
+        result["environment"]["(untagged)"].Sum(r => r.Cost).ShouldBe(120);
+    }
+
+    [Fact]
+    public void MultipleTags_EachTagGetsOwnUntaggedGroup()
+    {
+        var resources = new[]
+        {
+            CreateResource(10, new Dictionary<string, string> { { "environment", "prod" }, { "owner", "alice" } }),
+            CreateResource(20, new Dictionary<string, string> { { "environment", "dev" } }),
+            CreateResource(30, new Dictionary<string, string> { { "owner", "bob" } }),
+        };
+
+        var result = CostByTagCommand.GetResourcesByTag(resources, includeUntagged: true, "environment", "owner");
+
+        // environment tag: prod(10), dev(20), untagged(30 - missing environment)
+        result["environment"]["prod"].Count.ShouldBe(1);
+        result["environment"]["dev"].Count.ShouldBe(1);
+        result["environment"]["(untagged)"].Count.ShouldBe(1);
+        result["environment"]["(untagged)"][0].Cost.ShouldBe(30);
+
+        // owner tag: alice(10), bob(30), untagged(20 - missing owner)
+        result["owner"]["alice"].Count.ShouldBe(1);
+        result["owner"]["bob"].Count.ShouldBe(1);
+        result["owner"]["(untagged)"].Count.ShouldBe(1);
+        result["owner"]["(untagged)"][0].Cost.ShouldBe(20);
+    }
+
+    [Fact]
+    public void NoResources_ReturnsEmptyTagGroups()
+    {
+        var resources = Array.Empty<CostResourceItem>();
+
+        var result = CostByTagCommand.GetResourcesByTag(resources, includeUntagged: true, "environment");
+
+        result.ShouldContainKey("environment");
+        result["environment"].Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void IncludeUntaggedDefaultsToTrue()
+    {
+        var settings = new CostByTagSettings();
+        settings.IncludeUntagged.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

Resources without the requested tag(s) are now grouped under an `(untagged)` value in the `costByTag` command, making it easy to see what percentage of spend is properly tagged.

## Changes

- **`CostByTagSettings.cs`**: Added `--include-untagged` boolean flag (default: `true`)
- **`CostByTagCommand.cs`**: Updated `GetResourcesByTag` to include untagged resources in an `(untagged)` group; also handles null `Tags` dictionaries safely
- **`README.md`**: Documented the new flag and behavior
- **`CostByTagTests.cs`**: 9 unit tests covering tagged, untagged, mixed, null tags, multiple tags, and the opt-out flag

## Behavior

- `costByTag --tag environment` → resources without the `environment` tag appear under `(untagged)`
- `costByTag --tag environment --include-untagged false` → old behavior (untagged resources excluded)
- All existing formatters handle `(untagged)` naturally since it's just another tag value string