### PR TITLE
Add --fail-if-over cost threshold for CI/CD pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ jobs:
 
 The last step outputs the markdown to the Job Summary. This can be used to show the cost of the subscription in the workflow summary. Use it on a schedule to get for example a daily overview. Alternatively you can use the `-o json` parameter to get the results in JSON format and use it for further processing.
 
+## CI/CD Cost Gates
+
+Use the `--fail-if-over <amount>` flag to fail a pipeline step when costs exceed a threshold. When the total cost exceeds the specified amount, the command writes a warning to stderr and exits with code 1. Output is still written normally before the check, so piped output (e.g. to a file) is not affected.
+
+Supported commands: `accumulatedCost`, `costByResource`, `dailyCosts`.
+
+### Example: GitHub Actions cost gate
+
+```yaml
+- name: Check Azure costs
+  run: azure-cost accumulatedCost -s ${{ secrets.AZURE_SUBSCRIPTION_ID }} -o json --fail-if-over 500 > costs.json
+```
+
+If costs exceed 500, the step fails and the workflow stops (or you can use `continue-on-error: true` to proceed with a warning). The JSON output is still written to `costs.json` regardless.
+
 ## Available commands
 
 ### Accumulated Cost

--- a/src/Commands/AccumulatedCost/AccumulatedCostCommand.cs
+++ b/src/Commands/AccumulatedCost/AccumulatedCostCommand.cs
@@ -146,6 +146,9 @@ public class AccumulatedCostCommand : AsyncCommand<AccumulatedCostSettings>
         await _outputFormatters[settings.Output]
             .WriteAccumulatedCost(settings, accumulatedCost);
 
-        return 0;
+        // Check cost threshold after output
+        var totalCost = accumulatedCost.Costs.Sum(a => settings.UseUSD ? a.CostUsd : a.Cost);
+        var currency = settings.UseUSD ? "USD" : accumulatedCost.Costs.FirstOrDefault()?.Currency ?? "USD";
+        return CommandHelpers.CheckCostThreshold(totalCost, settings.FailIfOver, currency);
     }
 }

--- a/src/Commands/CommandHelpers.cs
+++ b/src/Commands/CommandHelpers.cs
@@ -59,4 +59,20 @@ public static class CommandHelpers
         if (debug)
             AnsiConsole.WriteLine($"Version: {typeof(CommandHelpers).Assembly.GetName().Version}");
     }
+
+    /// <summary>
+    /// Checks whether total cost exceeds the configured threshold.
+    /// Returns exit code 1 if exceeded, 0 otherwise. Writes a warning to stderr when exceeded.
+    /// </summary>
+    public static int CheckCostThreshold(double totalCost, double? threshold, string currency)
+    {
+        if (threshold.HasValue && totalCost > threshold.Value)
+        {
+            Console.Error.WriteLine(
+                $"Cost threshold exceeded: {totalCost:N2} {currency} > {threshold.Value:N2} {currency}");
+            return 1;
+        }
+
+        return 0;
+    }
 }

--- a/src/Commands/CostByResource/CostByResourceCommand.cs
+++ b/src/Commands/CostByResource/CostByResourceCommand.cs
@@ -51,6 +51,9 @@ public class CostByResourceCommand : AsyncCommand<CostByResourceSettings>
         await _outputFormatters[settings.Output]
             .WriteCostByResource(settings, resources);
 
-        return 0;
+        // Check cost threshold after output
+        var totalCost = resources.Sum(r => settings.UseUSD ? r.CostUSD : r.Cost);
+        var currency = settings.UseUSD ? "USD" : resources.FirstOrDefault()?.Currency ?? "USD";
+        return CommandHelpers.CheckCostThreshold(totalCost, settings.FailIfOver, currency);
     }
 }

--- a/src/Commands/CostSettings.cs
+++ b/src/Commands/CostSettings.cs
@@ -89,6 +89,10 @@ public class CostSettings : LogCommandSettings, ICostSettings
     [Description("Allows overriding the default HTTP timeout in seconds. Defaults to 100 seconds.")]
     public int HttpTimeout { get; set; } = 100;
     
+    [CommandOption("--fail-if-over")]
+    [Description("Fail with exit code 1 if total cost exceeds this amount. Useful for CI/CD cost gates. Not set by default.")]
+    public double? FailIfOver { get; set; }
+    
     /// <summary>
     /// Automatically sets the timeframe to Custom if both From and To dates are explicitly provided.
     /// This should be called during validation before using the Timeframe property.

--- a/src/Commands/DailyCost/DailyCost.cs
+++ b/src/Commands/DailyCost/DailyCost.cs
@@ -60,6 +60,9 @@ public class DailyCostCommand : AsyncCommand<DailyCostSettings>
         await _outputFormatters[settings.Output]
             .WriteDailyCost(settings, dailyCost);
 
-        return 0; // Omitted
+        // Check cost threshold after output
+        var totalCost = dailyCost.Sum(d => settings.UseUSD ? d.CostUsd : d.Cost);
+        var currency = settings.UseUSD ? "USD" : dailyCost.FirstOrDefault()?.Currency ?? "USD";
+        return CommandHelpers.CheckCostThreshold(totalCost, settings.FailIfOver, currency);
     }
 }

--- a/tests/AzureCostCli.Tests/Commands/ThresholdTests.cs
+++ b/tests/AzureCostCli.Tests/Commands/ThresholdTests.cs
@@ -1,0 +1,75 @@
+using AzureCostCli.Commands;
+using Shouldly;
+
+namespace AzureCostCli.Tests.Commands;
+
+public class ThresholdTests
+{
+    [Fact]
+    public void CheckCostThreshold_CostBelowThreshold_ReturnsZero()
+    {
+        var result = CommandHelpers.CheckCostThreshold(50.0, 100.0, "USD");
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CheckCostThreshold_CostAboveThreshold_ReturnsOne()
+    {
+        var result = CommandHelpers.CheckCostThreshold(150.0, 100.0, "USD");
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public void CheckCostThreshold_NullThreshold_ReturnsZero()
+    {
+        var result = CommandHelpers.CheckCostThreshold(150.0, null, "USD");
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CheckCostThreshold_CostExactlyAtThreshold_ReturnsZero()
+    {
+        var result = CommandHelpers.CheckCostThreshold(100.0, 100.0, "EUR");
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public void CheckCostThreshold_CostExceeded_WritesToStderr()
+    {
+        var originalErr = Console.Error;
+        using var sw = new StringWriter();
+        Console.SetError(sw);
+
+        try
+        {
+            CommandHelpers.CheckCostThreshold(150.0, 100.0, "USD");
+            var output = sw.ToString();
+            output.ShouldContain("Cost threshold exceeded");
+            output.ShouldContain("150");
+            output.ShouldContain("100");
+            output.ShouldContain("USD");
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+
+    [Fact]
+    public void CheckCostThreshold_CostNotExceeded_DoesNotWriteToStderr()
+    {
+        var originalErr = Console.Error;
+        using var sw = new StringWriter();
+        Console.SetError(sw);
+
+        try
+        {
+            CommandHelpers.CheckCostThreshold(50.0, 100.0, "USD");
+            sw.ToString().ShouldBeEmpty();
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+        }
+    }
+}

--- a/tests/AzureCostCli.Tests/Commands/ThresholdTests.cs
+++ b/tests/AzureCostCli.Tests/Commands/ThresholdTests.cs
@@ -3,6 +3,7 @@ using Shouldly;
 
 namespace AzureCostCli.Tests.Commands;
 
+[Collection("ConsoleOutputTests")]
 public class ThresholdTests
 {
     [Fact]


### PR DESCRIPTION
## Summary

Adds a `--fail-if-over <amount>` option that returns exit code 1 when costs exceed the specified threshold, enabling CI/CD cost gates.

## Changes

- **`CostSettings.cs`**: Added `FailIfOver` nullable double property with `--fail-if-over` CLI option
- **`CommandHelpers.cs`**: Added `CheckCostThreshold()` helper that compares cost vs threshold, writes warning to stderr, returns exit code
- **`AccumulatedCostCommand.cs`**: Threshold check after output (compares accumulated cost total)
- **`CostByResourceCommand.cs`**: Threshold check after output (compares sum of resource costs)
- **`DailyCost.cs`**: Threshold check after output (compares sum of daily costs)
- **`ThresholdTests.cs`**: 6 unit tests covering below/above/exact/null threshold and stderr output
- **`README.md`**: New "CI/CD Cost Gates" section with usage examples

## Design decisions

- Warning goes to **stderr** so piped stdout (`-o json > file.json`) is unaffected
- Output is written **before** the threshold check so users always see their data
- Respects `--useUSD` flag for currency-aware comparison
- Returns exit code 0 when threshold is not set (backward compatible)