### PR TITLE
Add --top and --sort parameters to costByResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,28 @@ A resource can be in multiple resource locations, like Intercontinental and West
 
 You can parse out the resource name, group name and subscription id from the ResourceId field. The format is `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}`.
 
+#### Sorting and limiting results
+
+Use `--sort` to control the order of resources. The default is `cost` (descending, most expensive first). Available options: `cost`, `cost-asc`, `name`, `resource-group`, `resource-type`, `location`.
+
+```bash
+azure-cost costByResource -s 574385a9-08e9-49fe-91a2-27660d92b8f5 --sort name
+```
+
+Use `--top N` to show only the top N resources. Use `0` to show all (the default).
+
+```bash
+azure-cost costByResource -s 574385a9-08e9-49fe-91a2-27660d92b8f5 --top 10
+```
+
+Combine both to get, for example, the 5 most expensive resources:
+
+```bash
+azure-cost costByResource -s 574385a9-08e9-49fe-91a2-27660d92b8f5 --top 5 --sort cost
+```
+
+> Note: `--top` limits the total number of resources passed to formatters. This is different from `--others-cutoff`, which collapses smaller items into an "Others" row in console output.
+
 ### Cost By Tag
 
 This will retrieve the cost of the subscription by the provided tag key(s). So if you tag your resources with, e.g. a `cost-center` or a `creator`, you can retrieve the cost of the subscription by those tags. You can specify multiple tags by using the `--tag` parameter multiple times. 

--- a/src/Commands/CostByResource/CostByResourceCommand.cs
+++ b/src/Commands/CostByResource/CostByResourceCommand.cs
@@ -50,27 +50,37 @@ public class CostByResourceCommand : AsyncCommand<CostByResourceSettings>
                     settings.GetToDate());
             });
 
-        // Sort resources
+        // Sort resources (use USD cost when UseUSD is set so ordering matches displayed amounts)
         resources = settings.Sort.ToLowerInvariant() switch
         {
-            "cost-asc" => resources.OrderBy(r => r.Cost),
+            "cost-asc" => resources.OrderBy(r => settings.UseUSD ? r.CostUSD : r.Cost),
             "name" => resources.OrderBy(r => r.ResourceId),
             "resource-group" => resources.OrderBy(r => r.ResourceGroupName),
             "resource-type" => resources.OrderBy(r => r.ResourceType),
             "location" => resources.OrderBy(r => r.ResourceLocation),
-            _ => resources.OrderByDescending(r => r.Cost) // "cost" and default
+            _ => resources.OrderByDescending(r => settings.UseUSD ? r.CostUSD : r.Cost) // "cost" and default
         };
 
         // Materialize to get total count/cost before truncating
         var allResources = resources.ToList();
-        var totalCount = allResources.Count;
+        var totalCount = allResources.Select(r => r.ResourceId).Distinct().Count();
         var totalCost = allResources.Sum(r => settings.UseUSD ? r.CostUSD : r.Cost);
         var currency = allResources.FirstOrDefault()?.Currency ?? "USD";
 
-        // Apply top filter
-        IEnumerable<CostResourceItem> outputResources = settings.Top > 0
-            ? allResources.Take(settings.Top)
-            : allResources;
+        // Apply top filter at the resource level so that all meter-detail rows
+        // for a selected resource are kept in the output.
+        IEnumerable<CostResourceItem> outputResources = allResources;
+        if (settings.Top > 0)
+        {
+            var topResourceIds = new HashSet<string>(
+                allResources
+                    .GroupBy(r => r.ResourceId ?? string.Empty)
+                    .OrderByDescending(g => g.Sum(r => settings.UseUSD ? r.CostUSD : r.Cost))
+                    .Take(settings.Top)
+                    .Select(g => g.Key));
+
+            outputResources = allResources.Where(r => topResourceIds.Contains(r.ResourceId ?? string.Empty));
+        }
 
         // Write the output
         await _outputFormatters[settings.Output]

--- a/src/Commands/CostByResource/CostByResourceCommand.cs
+++ b/src/Commands/CostByResource/CostByResourceCommand.cs
@@ -22,7 +22,10 @@ public class CostByResourceCommand : AsyncCommand<CostByResourceSettings>
             id => settings.Subscription = id);
         if (!subResult.Successful) return subResult;
 
-        return CommandHelpers.ValidateTimeframe(settings);
+        var timeframeResult = CommandHelpers.ValidateTimeframe(settings);
+        if (!timeframeResult.Successful) return timeframeResult;
+
+        return settings.ValidateCostByResourceSettings();
     }
 
     protected override async Task<int> ExecuteAsync(CommandContext context, CostByResourceSettings settings, CancellationToken cancellationToken)
@@ -47,9 +50,31 @@ public class CostByResourceCommand : AsyncCommand<CostByResourceSettings>
                     settings.GetToDate());
             });
 
+        // Sort resources
+        resources = settings.Sort.ToLowerInvariant() switch
+        {
+            "cost-asc" => resources.OrderBy(r => r.Cost),
+            "name" => resources.OrderBy(r => r.ResourceId),
+            "resource-group" => resources.OrderBy(r => r.ResourceGroupName),
+            "resource-type" => resources.OrderBy(r => r.ResourceType),
+            "location" => resources.OrderBy(r => r.ResourceLocation),
+            _ => resources.OrderByDescending(r => r.Cost) // "cost" and default
+        };
+
+        // Materialize to get total count/cost before truncating
+        var allResources = resources.ToList();
+        var totalCount = allResources.Count;
+        var totalCost = allResources.Sum(r => settings.UseUSD ? r.CostUSD : r.Cost);
+        var currency = allResources.FirstOrDefault()?.Currency ?? "USD";
+
+        // Apply top filter
+        IEnumerable<CostResourceItem> outputResources = settings.Top > 0
+            ? allResources.Take(settings.Top)
+            : allResources;
+
         // Write the output
         await _outputFormatters[settings.Output]
-            .WriteCostByResource(settings, resources);
+            .WriteCostByResource(settings, outputResources, totalCount, totalCost, currency);
 
         return 0;
     }

--- a/src/Commands/CostByResource/CostByResourceSettings.cs
+++ b/src/Commands/CostByResource/CostByResourceSettings.cs
@@ -1,12 +1,36 @@
 using System.ComponentModel;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace AzureCostCli.Commands.CostByResource;
 
 public class CostByResourceSettings : CostSettings
 {
+    private static readonly string[] ValidSortValues = ["cost", "cost-asc", "name", "resource-group", "resource-type", "location"];
+
     [CommandOption("--exclude-meter-details")]
     [Description("Exclude meter details from the output.")]
     [DefaultValue(false)]
     public bool ExcludeMeterDetails { get; set; }
+
+    [CommandOption("--top")]
+    [Description("Show only the top N resources. Use 0 to show all. Defaults to 0 (all).")]
+    [DefaultValue(0)]
+    public int Top { get; set; } = 0;
+
+    [CommandOption("--sort")]
+    [Description("Sort resources by field. Defaults to cost (descending). Options: cost, cost-asc, name, resource-group, resource-type, location.")]
+    [DefaultValue("cost")]
+    public string Sort { get; set; } = "cost";
+
+    public ValidationResult ValidateCostByResourceSettings()
+    {
+        if (Top < 0)
+            return ValidationResult.Error("The --top value must be 0 or greater.");
+
+        if (!ValidSortValues.Contains(Sort, StringComparer.OrdinalIgnoreCase))
+            return ValidationResult.Error($"Invalid --sort value '{Sort}'. Valid options: {string.Join(", ", ValidSortValues)}");
+
+        return ValidationResult.Success();
+    }
 }

--- a/src/OutputFormatters/BaseOutputFormatter.cs
+++ b/src/OutputFormatters/BaseOutputFormatter.cs
@@ -15,7 +15,8 @@ public abstract class BaseOutputFormatter
 {
     public abstract Task WriteAccumulatedCost(AccumulatedCostSettings settings,AccumulatedCostDetails accumulatedCostDetails);
 
-    public abstract Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources);
+    public abstract Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources,
+        int totalCount = 0, double totalCost = 0, string currency = "USD");
     
     public abstract Task WriteBudgets(BudgetsSettings settings, IEnumerable<BudgetItem> budgets);
 

--- a/src/OutputFormatters/ConsoleOutputFormatter.cs
+++ b/src/OutputFormatters/ConsoleOutputFormatter.cs
@@ -219,7 +219,7 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
             var tree = new Tree("Cost by resources");
             tree.Guide(TreeGuide.Line);
 
-            foreach (var resource in resources.OrderByDescending(a => a.Cost))
+            foreach (var resource in resources)
             {
                 var table = new Table()
                     .Border(TableBorder.SimpleHeavy)
@@ -278,7 +278,7 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
                 .AddColumn("Tags")
                 .AddColumn("Cost", column => column.Width(15).RightAligned());
 
-            foreach (var resource in resources.OrderByDescending(a => a.Cost))
+            foreach (var resource in resources)
             {
                 table.AddRow(new Markup("[bold]" + resource.ResourceId.Split('/').Last().EscapeMarkup() + "[/]"),
                     new Markup(resource.ResourceType.EscapeMarkup()),
@@ -293,11 +293,12 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
             AnsiConsole.Write(table);
         }
 
-        if (settings.Top > 0 && totalCount > 0)
+        if (settings.Top > 0 && totalCount > 0 && settings.Top < totalCount)
         {
+            var shownCount = Math.Min(settings.Top, totalCount);
             var costDisplay = settings.UseUSD ? $"{totalCost:N2} USD" : $"{totalCost:N2} {currency}";
             AnsiConsole.WriteLine();
-            AnsiConsole.MarkupLine($"[dim]Showing top {settings.Top} of {totalCount} resources (total cost: {costDisplay})[/]");
+            AnsiConsole.MarkupLine($"[dim]Showing top {shownCount} of {totalCount} resources (total cost: {costDisplay})[/]");
         }
 
         return Task.CompletedTask;

--- a/src/OutputFormatters/ConsoleOutputFormatter.cs
+++ b/src/OutputFormatters/ConsoleOutputFormatter.cs
@@ -210,7 +210,8 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
         return Task.CompletedTask;
     }
 
-    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources)
+    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources,
+        int totalCount = 0, double totalCost = 0, string currency = "USD")
     {
         // When we have meter details, we output the tree, otherwise we output a table
         if (settings.ExcludeMeterDetails == false)
@@ -290,6 +291,13 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
             }
 
             AnsiConsole.Write(table);
+        }
+
+        if (settings.Top > 0 && totalCount > 0)
+        {
+            var costDisplay = settings.UseUSD ? $"{totalCost:N2} USD" : $"{totalCost:N2} {currency}";
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine($"[dim]Showing top {settings.Top} of {totalCount} resources (total cost: {costDisplay})[/]");
         }
 
         return Task.CompletedTask;

--- a/src/OutputFormatters/CsvOutputFormatter.cs
+++ b/src/OutputFormatters/CsvOutputFormatter.cs
@@ -24,7 +24,8 @@ public class CsvOutputFormatter : BaseOutputFormatter
         return ExportToCsv(settings.SkipHeader, accumulatedCostDetails.Costs);
     }
 
-    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources)
+    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources,
+        int totalCount = 0, double totalCost = 0, string currency = "USD")
     {
         return ExportToCsv(settings.SkipHeader, resources);
     }

--- a/src/OutputFormatters/JsonOutputFormatter.cs
+++ b/src/OutputFormatters/JsonOutputFormatter.cs
@@ -50,7 +50,8 @@ public class JsonOutputFormatter : BaseOutputFormatter
         return Task.CompletedTask;
     }
 
-    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources)
+    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources,
+        int totalCount = 0, double totalCost = 0, string currency = "USD")
     {
         WriteJson(settings, resources);
         

--- a/src/OutputFormatters/MarkdownOutputFormatter.cs
+++ b/src/OutputFormatters/MarkdownOutputFormatter.cs
@@ -252,11 +252,12 @@ public class MarkdownOutputFormatter : BaseOutputFormatter
             }
         }
 
-        if (settings.Top > 0 && totalCount > 0)
+        if (settings.Top > 0 && totalCount > 0 && settings.Top < totalCount)
         {
+            var displayedCount = Math.Min(settings.Top, totalCount);
             var costDisplay = settings.UseUSD ? $"{totalCost:N2} USD" : $"{totalCost:N2} {currency}";
             Console.WriteLine();
-            Console.WriteLine($"> Showing top {settings.Top} of {totalCount} resources (total cost: {costDisplay})");
+            Console.WriteLine($"> Showing top {displayedCount} of {totalCount} resources (total cost: {costDisplay})");
         }
 
         return Task.CompletedTask;

--- a/src/OutputFormatters/MarkdownOutputFormatter.cs
+++ b/src/OutputFormatters/MarkdownOutputFormatter.cs
@@ -212,7 +212,8 @@ public class MarkdownOutputFormatter : BaseOutputFormatter
         return Task.CompletedTask;
     }
 
-    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources)
+    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources,
+        int totalCount = 0, double totalCost = 0, string currency = "USD")
     {
 
         if (settings.ExcludeMeterDetails)
@@ -249,6 +250,13 @@ public class MarkdownOutputFormatter : BaseOutputFormatter
                 Console.WriteLine(
                     $"|{cost.ResourceId.Split('/').Last()} | {cost.ResourceType} | {cost.ResourceLocation} | {cost.ResourceGroupName} |  {cost.ServiceName} | {cost.ServiceTier} | {cost.Meter} | {(settings.UseUSD ? cost.CostUSD : cost.Cost):N2} {(settings.UseUSD ? "USD" : cost.Currency)} |");
             }
+        }
+
+        if (settings.Top > 0 && totalCount > 0)
+        {
+            var costDisplay = settings.UseUSD ? $"{totalCost:N2} USD" : $"{totalCost:N2} {currency}";
+            Console.WriteLine();
+            Console.WriteLine($"> Showing top {settings.Top} of {totalCount} resources (total cost: {costDisplay})");
         }
 
         return Task.CompletedTask;

--- a/src/OutputFormatters/TextOutputFormatter.cs
+++ b/src/OutputFormatters/TextOutputFormatter.cs
@@ -100,7 +100,7 @@ public class TextOutputFormatter : BaseOutputFormatter
             Console.WriteLine();
         }
 
-        foreach (var resource in resources.OrderByDescending(a=>a.Cost))
+        foreach (var resource in resources)
         {
             if (settings.UseUSD)
             {
@@ -127,11 +127,12 @@ public class TextOutputFormatter : BaseOutputFormatter
 
         }
 
-        if (settings.Top > 0 && totalCount > 0)
+        if (settings.Top > 0 && totalCount > 0 && settings.Top < totalCount)
         {
+            var displayedCount = System.Math.Min(settings.Top, totalCount);
             var costDisplay = settings.UseUSD ? $"{totalCost:N2} USD" : $"{totalCost:N2} {currency}";
             Console.WriteLine();
-            Console.WriteLine($"Showing top {settings.Top} of {totalCount} resources (total cost: {costDisplay})");
+            Console.WriteLine($"Showing top {displayedCount} of {totalCount} resources (total cost: {costDisplay})");
         }
       
         return Task.CompletedTask;

--- a/src/OutputFormatters/TextOutputFormatter.cs
+++ b/src/OutputFormatters/TextOutputFormatter.cs
@@ -89,7 +89,8 @@ public class TextOutputFormatter : BaseOutputFormatter
         return Task.CompletedTask;
     }
 
-    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources)
+    public override Task WriteCostByResource(CostByResourceSettings settings, IEnumerable<CostResourceItem> resources,
+        int totalCount = 0, double totalCost = 0, string currency = "USD")
     {
         if (settings.SkipHeader == false)
         {
@@ -124,6 +125,13 @@ public class TextOutputFormatter : BaseOutputFormatter
                 }
             }
 
+        }
+
+        if (settings.Top > 0 && totalCount > 0)
+        {
+            var costDisplay = settings.UseUSD ? $"{totalCost:N2} USD" : $"{totalCost:N2} {currency}";
+            Console.WriteLine();
+            Console.WriteLine($"Showing top {settings.Top} of {totalCount} resources (total cost: {costDisplay})");
         }
       
         return Task.CompletedTask;

--- a/tests/AzureCostCli.Tests/Commands/CostByResourceCommandTests.cs
+++ b/tests/AzureCostCli.Tests/Commands/CostByResourceCommandTests.cs
@@ -105,6 +105,214 @@ public class CostByResourceCommandTests
         result.Successful.ShouldBeTrue();
     }
 
+    [Fact]
+    public void Validate_WithValidSortValues_ReturnsSuccess()
+    {
+        var validSorts = new[] { "cost", "cost-asc", "name", "resource-group", "resource-type", "location" };
+
+        foreach (var sort in validSorts)
+        {
+            var settings = new CostByResourceSettings
+            {
+                Timeframe = TimeframeType.MonthToDate,
+                Sort = sort
+            };
+            var context = CreateCommandContext();
+
+            var result = ValidateHelper.CallValidate(_command, context, settings);
+
+            result.Successful.ShouldBeTrue($"Sort value '{sort}' should be valid");
+        }
+    }
+
+    [Fact]
+    public void Validate_WithInvalidSortValue_ReturnsError()
+    {
+        var settings = new CostByResourceSettings
+        {
+            Timeframe = TimeframeType.MonthToDate,
+            Sort = "invalid"
+        };
+        var context = CreateCommandContext();
+
+        var result = ValidateHelper.CallValidate(_command, context, settings);
+
+        result.Successful.ShouldBeFalse();
+        result.Message.ShouldContain("Invalid --sort value");
+    }
+
+    [Fact]
+    public void Validate_WithNegativeTop_ReturnsError()
+    {
+        var settings = new CostByResourceSettings
+        {
+            Timeframe = TimeframeType.MonthToDate,
+            Top = -1
+        };
+        var context = CreateCommandContext();
+
+        var result = ValidateHelper.CallValidate(_command, context, settings);
+
+        result.Successful.ShouldBeFalse();
+        result.Message.ShouldContain("--top value must be 0 or greater");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(5)]
+    [InlineData(100)]
+    public void Validate_WithValidTopValues_ReturnsSuccess(int top)
+    {
+        var settings = new CostByResourceSettings
+        {
+            Timeframe = TimeframeType.MonthToDate,
+            Top = top
+        };
+        var context = CreateCommandContext();
+
+        var result = ValidateHelper.CallValidate(_command, context, settings);
+
+        result.Successful.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Settings_DefaultValues_AreCorrect()
+    {
+        var settings = new CostByResourceSettings();
+
+        settings.Top.ShouldBe(0);
+        settings.Sort.ShouldBe("cost");
+    }
+
+    [Fact]
+    public void SortByDefaultCost_OrdersDescending()
+    {
+        var resources = CreateTestResources(10);
+        var sorted = ApplySort(resources, "cost");
+
+        sorted.First().Cost.ShouldBe(9.0);
+        sorted.Last().Cost.ShouldBe(0.0);
+    }
+
+    [Fact]
+    public void SortByCostAsc_OrdersAscending()
+    {
+        var resources = CreateTestResources(10);
+        var sorted = ApplySort(resources, "cost-asc");
+
+        sorted.First().Cost.ShouldBe(0.0);
+        sorted.Last().Cost.ShouldBe(9.0);
+    }
+
+    [Fact]
+    public void SortByName_OrdersByResourceId()
+    {
+        var resources = CreateTestResources(5);
+        var sorted = ApplySort(resources, "name");
+
+        var names = sorted.Select(r => r.ResourceId).ToList();
+        names.ShouldBe(names.OrderBy(n => n).ToList());
+    }
+
+    [Fact]
+    public void SortByResourceGroup_OrdersByGroupName()
+    {
+        var resources = CreateTestResources(5);
+        var sorted = ApplySort(resources, "resource-group");
+
+        var groups = sorted.Select(r => r.ResourceGroupName).ToList();
+        groups.ShouldBe(groups.OrderBy(g => g).ToList());
+    }
+
+    [Fact]
+    public void SortByResourceType_OrdersByType()
+    {
+        var resources = CreateTestResources(5);
+        var sorted = ApplySort(resources, "resource-type");
+
+        var types = sorted.Select(r => r.ResourceType).ToList();
+        types.ShouldBe(types.OrderBy(t => t).ToList());
+    }
+
+    [Fact]
+    public void SortByLocation_OrdersByLocation()
+    {
+        var resources = CreateTestResources(5);
+        var sorted = ApplySort(resources, "location");
+
+        var locations = sorted.Select(r => r.ResourceLocation).ToList();
+        locations.ShouldBe(locations.OrderBy(l => l).ToList());
+    }
+
+    [Fact]
+    public void TopN_WithValueLessThanTotal_ReturnsTruncated()
+    {
+        var resources = CreateTestResources(20);
+        var sorted = ApplySort(resources, "cost");
+        var topped = sorted.Take(5).ToList();
+
+        topped.Count.ShouldBe(5);
+        topped.First().Cost.ShouldBe(19.0);
+    }
+
+    [Fact]
+    public void TopZero_ReturnsAll()
+    {
+        var resources = CreateTestResources(20);
+        int top = 0;
+        IEnumerable<CostResourceItem> result = top > 0 ? resources.Take(top) : resources;
+
+        result.Count().ShouldBe(20);
+    }
+
+    [Fact]
+    public void TopGreaterThanCount_ReturnsAll()
+    {
+        var resources = CreateTestResources(5);
+        var sorted = ApplySort(resources, "cost");
+        var topped = sorted.Take(100).ToList();
+
+        topped.Count.ShouldBe(5);
+    }
+
+    private static List<CostResourceItem> ApplySort(IEnumerable<CostResourceItem> resources, string sort)
+    {
+        IEnumerable<CostResourceItem> sorted = sort.ToLowerInvariant() switch
+        {
+            "cost-asc" => resources.OrderBy(r => r.Cost),
+            "name" => resources.OrderBy(r => r.ResourceId),
+            "resource-group" => resources.OrderBy(r => r.ResourceGroupName),
+            "resource-type" => resources.OrderBy(r => r.ResourceType),
+            "location" => resources.OrderBy(r => r.ResourceLocation),
+            _ => resources.OrderByDescending(r => r.Cost)
+        };
+        return sorted.ToList();
+    }
+
+    private static List<CostResourceItem> CreateTestResources(int count)
+    {
+        var locations = new[] { "westeurope", "eastus", "centralus", "northeurope", "westus2" };
+        var types = new[] { "Microsoft.Compute/virtualMachines", "Microsoft.Storage/storageAccounts",
+            "Microsoft.Sql/servers", "Microsoft.Web/sites", "Microsoft.Network/publicIPAddresses" };
+
+        return Enumerable.Range(0, count).Select(i =>
+            new CostResourceItem(
+                Cost: i * 1.0,
+                CostUSD: i * 1.1,
+                ResourceId: $"/subscriptions/sub/resourceGroups/rg-{i % 3}/providers/Microsoft.Compute/vm-{i:D3}",
+                ResourceType: types[i % types.Length],
+                ResourceLocation: locations[i % locations.Length],
+                ChargeType: "Usage",
+                ResourceGroupName: $"rg-{i % 3}",
+                PublisherType: "Azure",
+                ServiceName: "Virtual Machines",
+                ServiceTier: "Standard",
+                Meter: "Compute Hours",
+                Tags: new Dictionary<string, string>(),
+                Currency: "EUR"
+            )).ToList();
+    }
+
     private static CommandContext CreateCommandContext()
     {
         var remainingArguments = Mock.Of<IRemainingArguments>();

--- a/tests/AzureCostCli.Tests/Commands/CostByResourceCommandTests.cs
+++ b/tests/AzureCostCli.Tests/Commands/CostByResourceCommandTests.cs
@@ -275,16 +275,20 @@ public class CostByResourceCommandTests
         topped.Count.ShouldBe(5);
     }
 
-    private static List<CostResourceItem> ApplySort(IEnumerable<CostResourceItem> resources, string sort)
+    // NOTE: These sort/top tests exercise extracted sort logic that mirrors the
+    // command's switch expression. For full integration coverage (including
+    // formatter ordering), consider refactoring sort/top into a testable
+    // service that can be verified end-to-end.
+    private static List<CostResourceItem> ApplySort(IEnumerable<CostResourceItem> resources, string sort, bool useUSD = false)
     {
         IEnumerable<CostResourceItem> sorted = sort.ToLowerInvariant() switch
         {
-            "cost-asc" => resources.OrderBy(r => r.Cost),
+            "cost-asc" => resources.OrderBy(r => useUSD ? r.CostUSD : r.Cost),
             "name" => resources.OrderBy(r => r.ResourceId),
             "resource-group" => resources.OrderBy(r => r.ResourceGroupName),
             "resource-type" => resources.OrderBy(r => r.ResourceType),
             "location" => resources.OrderBy(r => r.ResourceLocation),
-            _ => resources.OrderByDescending(r => r.Cost)
+            _ => resources.OrderByDescending(r => useUSD ? r.CostUSD : r.Cost)
         };
         return sorted.ToList();
     }


### PR DESCRIPTION
## Summary

Adds `--top` and `--sort` parameters to the `costByResource` command, allowing users to focus on the most relevant resources.

### New parameters

- **`--top N`** — Show only the top N resources (default: 0 = all)
- **`--sort <field>`** — Sort by: `cost` (default, descending), `cost-asc`, `name`, `resource-group`, `resource-type`, `location`

### How it works

- Sort and top are applied in the command **before** passing to formatters, so all output formats benefit
- When `--top` is used, Console/Text/Markdown formatters show a summary line: *"Showing top 10 of 150 resources (total cost: X.XX)"*
- Validation ensures `--top >= 0` and `--sort` is a valid value
- `--top` is independent of the existing `--others-cutoff` parameter

### Examples

```bash
azure-cost costByResource --top 5 --sort cost
azure-cost costByResource --sort name -o json
azure-cost costByResource --top 10 -o text
```

### Testing

- Added unit tests for sorting (all 6 sort options), top filtering, validation, and default values
- All 35 CostByResource-related tests pass