### PR TITLE
Complete all missing formatter implementations

### DIFF
--- a/src/OutputFormatters/CsvOutputFormatter.cs
+++ b/src/OutputFormatters/CsvOutputFormatter.cs
@@ -149,8 +149,39 @@ public class CsvOutputFormatter : BaseOutputFormatter
     public override Task WriteAccumulatedDiffCost(DiffSettings settings, AccumulatedCostDetails accumulatedCostSource,
         AccumulatedCostDetails accumulatedCostTarget)
     {
-        return Task.CompletedTask;
+        var diffRows = new List<object>();
+
+        AddDiffRows(diffRows, "ServiceName", accumulatedCostSource.ByServiceNameCosts.ToList(),
+            accumulatedCostTarget.ByServiceNameCosts.ToList(), settings.UseUSD);
+        AddDiffRows(diffRows, "Location", accumulatedCostSource.ByLocationCosts.ToList(),
+            accumulatedCostTarget.ByLocationCosts.ToList(), settings.UseUSD);
+        AddDiffRows(diffRows, "ResourceGroup", accumulatedCostSource.ByResourceGroupCosts.ToList(),
+            accumulatedCostTarget.ByResourceGroupCosts.ToList(), settings.UseUSD);
+
+        return ExportToCsv(settings.SkipHeader, diffRows);
     }
+
+    private static void AddDiffRows(List<object> rows, string category,
+        List<CostNamedItem> sourceItems, List<CostNamedItem> targetItems, bool useUSD)
+    {
+        var allNames = sourceItems.Select(a => a.ItemName)
+            .Union(targetItems.Select(a => a.ItemName))
+            .Distinct()
+            .ToList();
+
+        foreach (var name in allNames)
+        {
+            var sourceCost = sourceItems.Where(a => a.ItemName == name).Sum(a => useUSD ? a.CostUsd : a.Cost);
+            var targetCost = targetItems.Where(a => a.ItemName == name).Sum(a => useUSD ? a.CostUsd : a.Cost);
+            var diff = targetCost - sourceCost;
+            var currency = sourceItems.Concat(targetItems).FirstOrDefault(a => a.ItemName == name)?.Currency ?? "USD";
+
+            rows.Add(new CostDiffRecord(category, name, sourceCost, targetCost, diff,
+                useUSD ? "USD" : currency));
+        }
+    }
+
+    private record CostDiffRecord(string Category, string Name, double SourceCost, double TargetCost, double Change, string Currency);
 
     public override Task WriteDevTestComparison(WhatIfSettings settings, IEnumerable<DevTestComparisonItem> items)
     {

--- a/src/OutputFormatters/CsvOutputFormatter.cs
+++ b/src/OutputFormatters/CsvOutputFormatter.cs
@@ -164,17 +164,40 @@ public class CsvOutputFormatter : BaseOutputFormatter
     private static void AddDiffRows(List<object> rows, string category,
         List<CostNamedItem> sourceItems, List<CostNamedItem> targetItems, bool useUSD)
     {
-        var allNames = sourceItems.Select(a => a.ItemName)
-            .Union(targetItems.Select(a => a.ItemName))
-            .Distinct()
+        var sourceCosts = sourceItems
+            .GroupBy(a => a.ItemName)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Sum(a => useUSD ? a.CostUsd : a.Cost));
+
+        var targetCosts = targetItems
+            .GroupBy(a => a.ItemName)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Sum(a => useUSD ? a.CostUsd : a.Cost));
+
+        var sourceCurrencies = sourceItems
+            .GroupBy(a => a.ItemName)
+            .ToDictionary(group => group.Key, group => group.First().Currency);
+
+        var targetCurrencies = targetItems
+            .GroupBy(a => a.ItemName)
+            .ToDictionary(group => group.Key, group => group.First().Currency);
+
+        var allNames = sourceCosts.Keys
+            .Union(targetCosts.Keys)
             .ToList();
 
         foreach (var name in allNames)
         {
-            var sourceCost = sourceItems.Where(a => a.ItemName == name).Sum(a => useUSD ? a.CostUsd : a.Cost);
-            var targetCost = targetItems.Where(a => a.ItemName == name).Sum(a => useUSD ? a.CostUsd : a.Cost);
+            sourceCosts.TryGetValue(name, out var sourceCost);
+            targetCosts.TryGetValue(name, out var targetCost);
+
             var diff = targetCost - sourceCost;
-            var currency = sourceItems.Concat(targetItems).FirstOrDefault(a => a.ItemName == name)?.Currency ?? "USD";
+            var currency =
+                (sourceCurrencies.TryGetValue(name, out var sourceCurrency) ? sourceCurrency : null)
+                ?? (targetCurrencies.TryGetValue(name, out var targetCurrency) ? targetCurrency : null)
+                ?? "USD";
 
             rows.Add(new CostDiffRecord(category, name, sourceCost, targetCost, diff,
                 useUSD ? "USD" : currency));

--- a/src/OutputFormatters/TextOutputFormatter.cs
+++ b/src/OutputFormatters/TextOutputFormatter.cs
@@ -238,7 +238,81 @@ public class TextOutputFormatter : BaseOutputFormatter
     public override Task WriteAccumulatedDiffCost(DiffSettings settings, AccumulatedCostDetails accumulatedCostSource,
         AccumulatedCostDetails accumulatedCostTarget)
     {
+        var culture = CultureInfo.GetCultureInfo("en-US");
+        var currency = "USD";
+        if (!settings.UseUSD)
+        {
+            var firstCost = accumulatedCostSource.Costs.FirstOrDefault();
+            if (firstCost != null && !string.IsNullOrEmpty(firstCost.Currency))
+            {
+                currency = firstCost.Currency;
+            }
+        }
+
+        var sourceRange = accumulatedCostSource.Costs.Any()
+            ? $"{accumulatedCostSource.Costs.Min(a => a.Date)} to {accumulatedCostSource.Costs.Max(a => a.Date)}"
+            : "N/A";
+        var targetRange = accumulatedCostTarget.Costs.Any()
+            ? $"{accumulatedCostTarget.Costs.Min(a => a.Date)} to {accumulatedCostTarget.Costs.Max(a => a.Date)}"
+            : "N/A";
+
+        Console.WriteLine("Azure Cost Diff");
+        Console.WriteLine();
+        Console.WriteLine($"Source: {sourceRange}");
+        Console.WriteLine($"Target: {targetRange}");
+
+        Console.WriteLine();
+        Console.WriteLine("By Service Name:");
+        WriteComparisonSection(accumulatedCostSource.ByServiceNameCosts.ToList(),
+            accumulatedCostTarget.ByServiceNameCosts.ToList(), settings.UseUSD, currency, culture);
+
+        Console.WriteLine();
+        Console.WriteLine("By Location:");
+        WriteComparisonSection(accumulatedCostSource.ByLocationCosts.ToList(),
+            accumulatedCostTarget.ByLocationCosts.ToList(), settings.UseUSD, currency, culture);
+
+        Console.WriteLine();
+        Console.WriteLine("By Resource Group:");
+        WriteComparisonSection(accumulatedCostSource.ByResourceGroupCosts.ToList(),
+            accumulatedCostTarget.ByResourceGroupCosts.ToList(), settings.UseUSD, currency, culture);
+
+        var totalSource = accumulatedCostSource.Costs.Sum(a => settings.UseUSD ? a.CostUsd : a.Cost);
+        var totalTarget = accumulatedCostTarget.Costs.Sum(a => settings.UseUSD ? a.CostUsd : a.Cost);
+        var totalDiff = totalTarget - totalSource;
+        var totalDiffSign = totalDiff >= 0 ? "+" : "";
+
+        Console.WriteLine();
+        Console.WriteLine("Summary:");
+        Console.WriteLine($"  Source Total: {totalSource.ToString("N2", culture)} {currency}");
+        Console.WriteLine($"  Target Total: {totalTarget.ToString("N2", culture)} {currency}");
+        Console.WriteLine($"  Change: {totalDiffSign}{totalDiff.ToString("N2", culture)} {currency}");
+
         return Task.CompletedTask;
+    }
+
+    private static void WriteComparisonSection(
+        List<CostNamedItem> sourceItems,
+        List<CostNamedItem> targetItems,
+        bool useUSD,
+        string currency,
+        CultureInfo culture)
+    {
+        var allItems = sourceItems.Select(a => a.ItemName)
+            .Union(targetItems.Select(a => a.ItemName))
+            .OrderByDescending(name =>
+                Math.Max(
+                    sourceItems.Where(a => a.ItemName == name).Sum(a => useUSD ? a.CostUsd : a.Cost),
+                    targetItems.Where(a => a.ItemName == name).Sum(a => useUSD ? a.CostUsd : a.Cost)))
+            .ToList();
+
+        foreach (var item in allItems)
+        {
+            var sourceCost = sourceItems.Where(a => a.ItemName == item).Sum(a => useUSD ? a.CostUsd : a.Cost);
+            var targetCost = targetItems.Where(a => a.ItemName == item).Sum(a => useUSD ? a.CostUsd : a.Cost);
+            var diff = targetCost - sourceCost;
+            var diffSign = diff >= 0 ? "+" : "";
+            Console.WriteLine($"  {item}: {sourceCost.ToString("N2", culture)} -> {targetCost.ToString("N2", culture)} ({diffSign}{diff.ToString("N2", culture)}) {currency}");
+        }
     }
     
     public override Task WriteRegions(RegionsSettings settings, IReadOnlyCollection<AzureRegion> regions)

--- a/src/OutputFormatters/TextOutputFormatter.cs
+++ b/src/OutputFormatters/TextOutputFormatter.cs
@@ -238,16 +238,37 @@ public class TextOutputFormatter : BaseOutputFormatter
     public override Task WriteAccumulatedDiffCost(DiffSettings settings, AccumulatedCostDetails accumulatedCostSource,
         AccumulatedCostDetails accumulatedCostTarget)
     {
-        var culture = CultureInfo.GetCultureInfo("en-US");
-        var currency = "USD";
-        if (!settings.UseUSD)
+        var culture = CultureInfo.CurrentCulture;
+
+        string GetPreferredCurrency()
         {
-            var firstCost = accumulatedCostSource.Costs.FirstOrDefault();
-            if (firstCost != null && !string.IsNullOrEmpty(firstCost.Currency))
+            var currencySources = new[]
             {
-                currency = firstCost.Currency;
+                accumulatedCostSource.Costs.Select(a => a.Currency),
+                accumulatedCostTarget.Costs.Select(a => a.Currency),
+                accumulatedCostSource.ByServiceNameCosts.Select(a => a.Currency),
+                accumulatedCostTarget.ByServiceNameCosts.Select(a => a.Currency),
+                accumulatedCostSource.ByLocationCosts.Select(a => a.Currency),
+                accumulatedCostTarget.ByLocationCosts.Select(a => a.Currency),
+                accumulatedCostSource.ByResourceGroupCosts.Select(a => a.Currency),
+                accumulatedCostTarget.ByResourceGroupCosts.Select(a => a.Currency)
+            };
+
+            foreach (var currencySource in currencySources)
+            {
+                foreach (var candidateCurrency in currencySource)
+                {
+                    if (!string.IsNullOrWhiteSpace(candidateCurrency))
+                    {
+                        return candidateCurrency;
+                    }
+                }
             }
+
+            return "USD";
         }
+
+        var currency = settings.UseUSD ? "USD" : GetPreferredCurrency();
 
         var sourceRange = accumulatedCostSource.Costs.Any()
             ? $"{accumulatedCostSource.Costs.Min(a => a.Date)} to {accumulatedCostSource.Costs.Max(a => a.Date)}"
@@ -297,18 +318,26 @@ public class TextOutputFormatter : BaseOutputFormatter
         string currency,
         CultureInfo culture)
     {
-        var allItems = sourceItems.Select(a => a.ItemName)
-            .Union(targetItems.Select(a => a.ItemName))
+        var sourceCosts = sourceItems
+            .GroupBy(a => a.ItemName)
+            .ToDictionary(g => g.Key, g => g.Sum(a => useUSD ? a.CostUsd : a.Cost));
+
+        var targetCosts = targetItems
+            .GroupBy(a => a.ItemName)
+            .ToDictionary(g => g.Key, g => g.Sum(a => useUSD ? a.CostUsd : a.Cost));
+
+        var allItems = sourceCosts.Keys
+            .Union(targetCosts.Keys)
             .OrderByDescending(name =>
                 Math.Max(
-                    sourceItems.Where(a => a.ItemName == name).Sum(a => useUSD ? a.CostUsd : a.Cost),
-                    targetItems.Where(a => a.ItemName == name).Sum(a => useUSD ? a.CostUsd : a.Cost)))
+                    sourceCosts.GetValueOrDefault(name),
+                    targetCosts.GetValueOrDefault(name)))
             .ToList();
 
         foreach (var item in allItems)
         {
-            var sourceCost = sourceItems.Where(a => a.ItemName == item).Sum(a => useUSD ? a.CostUsd : a.Cost);
-            var targetCost = targetItems.Where(a => a.ItemName == item).Sum(a => useUSD ? a.CostUsd : a.Cost);
+            sourceCosts.TryGetValue(item, out var sourceCost);
+            targetCosts.TryGetValue(item, out var targetCost);
             var diff = targetCost - sourceCost;
             var diffSign = diff >= 0 ? "+" : "";
             Console.WriteLine($"  {item}: {sourceCost.ToString("N2", culture)} -> {targetCost.ToString("N2", culture)} ({diffSign}{diff.ToString("N2", culture)}) {currency}");

--- a/tests/AzureCostCli.Tests/OutputFormatters/FormatterGapTests.cs
+++ b/tests/AzureCostCli.Tests/OutputFormatters/FormatterGapTests.cs
@@ -55,7 +55,7 @@ public class FormatterGapTests
     #region TextOutputFormatter.WriteAccumulatedDiffCost
 
     [Fact]
-    public async Task Text_WriteAccumulatedDiffCost_ProducesOutput()
+    public void Text_WriteAccumulatedDiffCost_ProducesOutput()
     {
         var formatter = new TextOutputFormatter();
         var source = CreateSampleDiffDetails(1.0);
@@ -75,7 +75,7 @@ public class FormatterGapTests
     }
 
     [Fact]
-    public async Task Text_WriteAccumulatedDiffCost_ShowsChangeSign()
+    public void Text_WriteAccumulatedDiffCost_ShowsChangeSign()
     {
         var formatter = new TextOutputFormatter();
         var source = CreateSampleDiffDetails(1.0);
@@ -89,7 +89,7 @@ public class FormatterGapTests
     }
 
     [Fact]
-    public async Task Text_WriteAccumulatedDiffCost_EmptyCosts_ProducesOutput()
+    public void Text_WriteAccumulatedDiffCost_EmptyCosts_ProducesOutput()
     {
         var formatter = new TextOutputFormatter();
         var empty = new AccumulatedCostDetails(
@@ -111,7 +111,7 @@ public class FormatterGapTests
     #region CsvOutputFormatter.WriteAccumulatedDiffCost
 
     [Fact]
-    public async Task Csv_WriteAccumulatedDiffCost_ProducesOutput()
+    public void Csv_WriteAccumulatedDiffCost_ProducesOutput()
     {
         var formatter = new CsvOutputFormatter();
         var source = CreateSampleDiffDetails(1.0);
@@ -130,7 +130,7 @@ public class FormatterGapTests
     }
 
     [Fact]
-    public async Task Csv_WriteAccumulatedDiffCost_ContainsAllCategories()
+    public void Csv_WriteAccumulatedDiffCost_ContainsAllCategories()
     {
         var formatter = new CsvOutputFormatter();
         var source = CreateSampleDiffDetails(1.0);
@@ -148,7 +148,7 @@ public class FormatterGapTests
     }
 
     [Fact]
-    public async Task Csv_WriteAccumulatedDiffCost_EmptyCosts_ProducesEmptyOutput()
+    public void Csv_WriteAccumulatedDiffCost_EmptyCosts_ProducesEmptyOutput()
     {
         var formatter = new CsvOutputFormatter();
         var empty = new AccumulatedCostDetails(
@@ -165,7 +165,7 @@ public class FormatterGapTests
     }
 
     [Fact]
-    public async Task Csv_WriteAccumulatedDiffCost_SkipHeader()
+    public void Csv_WriteAccumulatedDiffCost_SkipHeader()
     {
         var formatter = new CsvOutputFormatter();
         var source = CreateSampleDiffDetails(1.0);

--- a/tests/AzureCostCli.Tests/OutputFormatters/FormatterGapTests.cs
+++ b/tests/AzureCostCli.Tests/OutputFormatters/FormatterGapTests.cs
@@ -1,0 +1,199 @@
+using AzureCostCli.Commands.Diff;
+using AzureCostCli.CostApi;
+using AzureCostCli.OutputFormatters;
+using Shouldly;
+
+namespace AzureCostCli.Tests.OutputFormatters;
+
+[Collection("ConsoleOutputTests")]
+public class FormatterGapTests
+{
+    private static readonly Subscription TestSubscription = new(
+        id: "/subscriptions/00000000-0000-0000-0000-000000000000",
+        authorizationSource: "RoleBased",
+        managedByTenants: Array.Empty<object>(),
+        subscriptionId: "00000000-0000-0000-0000-000000000000",
+        tenantId: "00000000-0000-0000-0000-000000000001",
+        displayName: "Test Subscription",
+        state: "Enabled",
+        subscriptionPolicies: new SubscriptionPolicies("Internal_2014-09-01", "EnterpriseAgreement_2014-09-01", "Off"));
+
+    private static AccumulatedCostDetails CreateSampleDiffDetails(double costMultiplier = 1.0)
+    {
+        var costs = new List<CostItem>
+        {
+            new(new DateOnly(2024, 1, 1), 100 * costMultiplier, 100 * costMultiplier, "USD"),
+            new(new DateOnly(2024, 1, 2), 150 * costMultiplier, 150 * costMultiplier, "USD"),
+        };
+        var byService = new List<CostNamedItem>
+        {
+            new("Virtual Machines", 180 * costMultiplier, 180 * costMultiplier, "USD"),
+            new("Storage", 70 * costMultiplier, 70 * costMultiplier, "USD"),
+        };
+        var byLocation = new List<CostNamedItem>
+        {
+            new("eastus", 200 * costMultiplier, 200 * costMultiplier, "USD"),
+            new("westus", 50 * costMultiplier, 50 * costMultiplier, "USD"),
+        };
+        var byResourceGroup = new List<CostNamedItem>
+        {
+            new("rg-prod", 190 * costMultiplier, 190 * costMultiplier, "USD"),
+            new("rg-dev", 60 * costMultiplier, 60 * costMultiplier, "USD"),
+        };
+
+        return new AccumulatedCostDetails(
+            TestSubscription, null, costs, Enumerable.Empty<CostItem>(),
+            byService, byLocation, byResourceGroup, null);
+    }
+
+    private static DiffSettings CreateDiffSettings() => new()
+    {
+        CompareTo = "target.json",
+        CompareFrom = "source.json",
+    };
+
+    #region TextOutputFormatter.WriteAccumulatedDiffCost
+
+    [Fact]
+    public async Task Text_WriteAccumulatedDiffCost_ProducesOutput()
+    {
+        var formatter = new TextOutputFormatter();
+        var source = CreateSampleDiffDetails(1.0);
+        var target = CreateSampleDiffDetails(1.2);
+        var settings = CreateDiffSettings();
+
+        var output = CaptureConsoleOutput(() => formatter.WriteAccumulatedDiffCost(settings, source, target));
+
+        output.ShouldNotBeNullOrWhiteSpace();
+        output.ShouldContain("Azure Cost Diff");
+        output.ShouldContain("By Service Name:");
+        output.ShouldContain("By Location:");
+        output.ShouldContain("By Resource Group:");
+        output.ShouldContain("Virtual Machines");
+        output.ShouldContain("Storage");
+        output.ShouldContain("Summary:");
+    }
+
+    [Fact]
+    public async Task Text_WriteAccumulatedDiffCost_ShowsChangeSign()
+    {
+        var formatter = new TextOutputFormatter();
+        var source = CreateSampleDiffDetails(1.0);
+        var target = CreateSampleDiffDetails(1.5);
+        var settings = CreateDiffSettings();
+
+        var output = CaptureConsoleOutput(() => formatter.WriteAccumulatedDiffCost(settings, source, target));
+
+        // Cost increased, so we should see "+" signs
+        output.ShouldContain("+");
+    }
+
+    [Fact]
+    public async Task Text_WriteAccumulatedDiffCost_EmptyCosts_ProducesOutput()
+    {
+        var formatter = new TextOutputFormatter();
+        var empty = new AccumulatedCostDetails(
+            TestSubscription, null,
+            Enumerable.Empty<CostItem>(), Enumerable.Empty<CostItem>(),
+            Enumerable.Empty<CostNamedItem>(), Enumerable.Empty<CostNamedItem>(),
+            Enumerable.Empty<CostNamedItem>(), null);
+        var settings = CreateDiffSettings();
+
+        var output = CaptureConsoleOutput(() => formatter.WriteAccumulatedDiffCost(settings, empty, empty));
+
+        output.ShouldNotBeNullOrWhiteSpace();
+        output.ShouldContain("Azure Cost Diff");
+        output.ShouldContain("N/A");
+    }
+
+    #endregion
+
+    #region CsvOutputFormatter.WriteAccumulatedDiffCost
+
+    [Fact]
+    public async Task Csv_WriteAccumulatedDiffCost_ProducesOutput()
+    {
+        var formatter = new CsvOutputFormatter();
+        var source = CreateSampleDiffDetails(1.0);
+        var target = CreateSampleDiffDetails(1.2);
+        var settings = CreateDiffSettings();
+
+        var output = CaptureConsoleOutput(() => formatter.WriteAccumulatedDiffCost(settings, source, target));
+
+        output.ShouldNotBeNullOrWhiteSpace();
+        // Should contain CSV header
+        output.ShouldContain("Category");
+        output.ShouldContain("Name");
+        output.ShouldContain("SourceCost");
+        output.ShouldContain("TargetCost");
+        output.ShouldContain("Change");
+    }
+
+    [Fact]
+    public async Task Csv_WriteAccumulatedDiffCost_ContainsAllCategories()
+    {
+        var formatter = new CsvOutputFormatter();
+        var source = CreateSampleDiffDetails(1.0);
+        var target = CreateSampleDiffDetails(1.2);
+        var settings = CreateDiffSettings();
+
+        var output = CaptureConsoleOutput(() => formatter.WriteAccumulatedDiffCost(settings, source, target));
+
+        output.ShouldContain("ServiceName");
+        output.ShouldContain("Location");
+        output.ShouldContain("ResourceGroup");
+        output.ShouldContain("Virtual Machines");
+        output.ShouldContain("eastus");
+        output.ShouldContain("rg-prod");
+    }
+
+    [Fact]
+    public async Task Csv_WriteAccumulatedDiffCost_EmptyCosts_ProducesEmptyOutput()
+    {
+        var formatter = new CsvOutputFormatter();
+        var empty = new AccumulatedCostDetails(
+            TestSubscription, null,
+            Enumerable.Empty<CostItem>(), Enumerable.Empty<CostItem>(),
+            Enumerable.Empty<CostNamedItem>(), Enumerable.Empty<CostNamedItem>(),
+            Enumerable.Empty<CostNamedItem>(), null);
+        var settings = CreateDiffSettings();
+
+        var output = CaptureConsoleOutput(() => formatter.WriteAccumulatedDiffCost(settings, empty, empty));
+
+        // With no data, CsvHelper produces no output
+        output.Trim().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task Csv_WriteAccumulatedDiffCost_SkipHeader()
+    {
+        var formatter = new CsvOutputFormatter();
+        var source = CreateSampleDiffDetails(1.0);
+        var target = CreateSampleDiffDetails(1.2);
+        var settings = CreateDiffSettings();
+        settings.SkipHeader = true;
+
+        var output = CaptureConsoleOutput(() => formatter.WriteAccumulatedDiffCost(settings, source, target));
+
+        // Should not contain header names
+        output.ShouldNotContain("Category,Name,SourceCost");
+    }
+
+    #endregion
+
+    private static string CaptureConsoleOutput(Func<Task> action)
+    {
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+        try
+        {
+            action().GetAwaiter().GetResult();
+            return writer.ToString();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the two remaining stub methods that returned `Task.CompletedTask` without producing any output:

### TextOutputFormatter.WriteAccumulatedDiffCost
- Plain text diff output showing cost changes by service name, location, and resource group
- Source → target comparison with +/- change indicators
- Summary section with totals

### CsvOutputFormatter.WriteAccumulatedDiffCost  
- CSV export using CsvHelper with columns: Category, Name, SourceCost, TargetCost, Change, Currency
- Covers all three comparison dimensions (ServiceName, Location, ResourceGroup)
- Respects SkipHeader setting

### Tests
- 7 new tests in `FormatterGapTests.cs` covering:
  - Output is non-empty and contains expected content
  - Change signs (+/-) are present
  - Empty data edge case
  - Skip header behavior
  - All categories present in CSV output

### Notes
The other methods mentioned in the issue (MarkdownOutputFormatter.WriteCostByResource, WriteAnomalyDetectionResults, WriteDevTestComparison, and CsvOutputFormatter.WriteDevTestComparison) were already implemented on this branch.