### PR TITLE
Translate deprecated TheLastMonth/TheLastBillingMonth timeframes to Custom

### DIFF
--- a/src/CostApi/AzureCostApiRetriever.cs
+++ b/src/CostApi/AzureCostApiRetriever.cs
@@ -44,6 +44,26 @@ public class AzureCostApiRetriever : ICostRetriever
         _client = httpClientFactory.CreateClient("CostApi");
     }
 
+    /// <summary>
+    /// Translates deprecated timeframe values (TheLastMonth, TheLastBillingMonth) into Custom
+    /// timeframes with explicit date ranges, since the Azure Cost Management API no longer supports them.
+    /// The <paramref name="today"/> parameter ensures consistent date resolution across multiple API calls.
+    /// </summary>
+    internal static (TimeframeType TimeFrame, DateOnly From, DateOnly To) ResolveTimeframe(
+        TimeframeType timeFrame, DateOnly from, DateOnly to, DateOnly today)
+    {
+        switch (timeFrame)
+        {
+            case TimeframeType.TheLastMonth:
+            case TimeframeType.TheLastBillingMonth:
+                var lastMonthStart = new DateOnly(today.Year, today.Month, 1).AddMonths(-1);
+                var lastMonthEnd = lastMonthStart.AddMonths(1).AddDays(-1);
+                return (TimeframeType.Custom, lastMonthStart, lastMonthEnd);
+            default:
+                return (timeFrame, from, to);
+        }
+    }
+
     private async Task RetrieveToken(bool includeDebugOutput)
     {
         if (_tokenRetrieved)
@@ -242,15 +262,16 @@ public class AzureCostApiRetriever : ICostRetriever
         var filters = GenerateFilters(filter);
         var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
+        var resolved = ResolveTimeframe(timeFrame, from, to, DateOnly.FromDateTime(DateTime.UtcNow));
         var payload = new
         {
             type = metric.ToString(),
-            timeframe = timeFrame.ToString(),
-            timePeriod = timeFrame == TimeframeType.Custom
+            timeframe = resolved.TimeFrame.ToString(),
+            timePeriod = resolved.TimeFrame == TimeframeType.Custom
                 ? new
                 {
-                    from = from.ToString("yyyy-MM-dd"),
-                    to = to.ToString("yyyy-MM-dd")
+                    from = resolved.From.ToString("yyyy-MM-dd"),
+                    to = resolved.To.ToString("yyyy-MM-dd")
                 }
                 : null,
             dataSet = new
@@ -306,15 +327,16 @@ public class AzureCostApiRetriever : ICostRetriever
     {
         var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
+        var resolved = ResolveTimeframe(timeFrame, from, to, DateOnly.FromDateTime(DateTime.UtcNow));
         var payload = new
         {
             type = metric.ToString(),
-            timeframe = timeFrame.ToString(),
-            timePeriod = timeFrame == TimeframeType.Custom
+            timeframe = resolved.TimeFrame.ToString(),
+            timePeriod = resolved.TimeFrame == TimeframeType.Custom
                 ? new
                 {
-                    from = from.ToString("yyyy-MM-dd"),
-                    to = to.ToString("yyyy-MM-dd")
+                    from = resolved.From.ToString("yyyy-MM-dd"),
+                    to = resolved.To.ToString("yyyy-MM-dd")
                 }
                 : null,
             dataSet = new
@@ -376,15 +398,16 @@ public class AzureCostApiRetriever : ICostRetriever
     {
         var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
+        var resolved = ResolveTimeframe(timeFrame, from, to, DateOnly.FromDateTime(DateTime.UtcNow));
         var payload = new
         {
             type = metric.ToString(),
-            timeframe = timeFrame.ToString(),
-            timePeriod = timeFrame == TimeframeType.Custom
+            timeframe = resolved.TimeFrame.ToString(),
+            timePeriod = resolved.TimeFrame == TimeframeType.Custom
                 ? new
                 {
-                    from = from.ToString("yyyy-MM-dd"),
-                    to = to.ToString("yyyy-MM-dd")
+                    from = resolved.From.ToString("yyyy-MM-dd"),
+                    to = resolved.To.ToString("yyyy-MM-dd")
                 }
                 : null,
             dataSet = new
@@ -446,15 +469,16 @@ public class AzureCostApiRetriever : ICostRetriever
     {
         var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
+        var resolved = ResolveTimeframe(timeFrame, from, to, DateOnly.FromDateTime(DateTime.UtcNow));
         var payload = new
         {
             type = metric.ToString(),
-            timeframe = timeFrame.ToString(),
-            timePeriod = timeFrame == TimeframeType.Custom
+            timeframe = resolved.TimeFrame.ToString(),
+            timePeriod = resolved.TimeFrame == TimeframeType.Custom
                 ? new
                 {
-                    from = from.ToString("yyyy-MM-dd"),
-                    to = to.ToString("yyyy-MM-dd")
+                    from = resolved.From.ToString("yyyy-MM-dd"),
+                    to = resolved.To.ToString("yyyy-MM-dd")
                 }
                 : null,
             dataSet = new
@@ -521,15 +545,16 @@ public class AzureCostApiRetriever : ICostRetriever
     {
         var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
+        var resolved = ResolveTimeframe(timeFrame, from, to, DateOnly.FromDateTime(DateTime.UtcNow));
         var payload = new
         {
             type = metric.ToString(),
-            timeframe = timeFrame.ToString(),
-            timePeriod = timeFrame == TimeframeType.Custom
+            timeframe = resolved.TimeFrame.ToString(),
+            timePeriod = resolved.TimeFrame == TimeframeType.Custom
                 ? new
                 {
-                    from = from.ToString("yyyy-MM-dd"),
-                    to = to.ToString("yyyy-MM-dd")
+                    from = resolved.From.ToString("yyyy-MM-dd"),
+                    to = resolved.To.ToString("yyyy-MM-dd")
                 }
                 : null,
             dataSet = new
@@ -596,15 +621,16 @@ public class AzureCostApiRetriever : ICostRetriever
     {
         var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/query?api-version=2023-03-01&$top=5000");
 
+        var resolved = ResolveTimeframe(timeFrame, from, to, DateOnly.FromDateTime(DateTime.UtcNow));
         var payload = new
         {
             type = metric.ToString(),
-            timeframe = timeFrame.ToString(),
-            timePeriod = timeFrame == TimeframeType.Custom
+            timeframe = resolved.TimeFrame.ToString(),
+            timePeriod = resolved.TimeFrame == TimeframeType.Custom
                 ? new
                 {
-                    from = from.ToString("yyyy-MM-dd"),
-                    to = to.ToString("yyyy-MM-dd")
+                    from = resolved.From.ToString("yyyy-MM-dd"),
+                    to = resolved.To.ToString("yyyy-MM-dd")
                 }
                 : null,
             dataSet = new
@@ -718,15 +744,16 @@ public class AzureCostApiRetriever : ICostRetriever
     {
         var uri = DeterminePath(scope, "/providers/Microsoft.CostManagement/forecast?api-version=2021-10-01&$top=5000");
 
+        var resolved = ResolveTimeframe(timeFrame, from, to, DateOnly.FromDateTime(DateTime.UtcNow));
         var payload = new
         {
             type = metric.ToString(),
-            timeframe = timeFrame.ToString(),
-            timePeriod = timeFrame == TimeframeType.Custom
+            timeframe = resolved.TimeFrame.ToString(),
+            timePeriod = resolved.TimeFrame == TimeframeType.Custom
                 ? new
                 {
-                    from = from.ToString("yyyy-MM-dd"),
-                    to = to.ToString("yyyy-MM-dd")
+                    from = resolved.From.ToString("yyyy-MM-dd"),
+                    to = resolved.To.ToString("yyyy-MM-dd")
                 }
                 : null,
             dataSet = new
@@ -878,15 +905,16 @@ public class AzureCostApiRetriever : ICostRetriever
             };
         }
 
+        var resolved = ResolveTimeframe(timeFrame, from, to, DateOnly.FromDateTime(DateTime.UtcNow));
         var payload = new
         {
             type = metric.ToString(),
-            timeframe = timeFrame.ToString(),
-            timePeriod = timeFrame == TimeframeType.Custom
+            timeframe = resolved.TimeFrame.ToString(),
+            timePeriod = resolved.TimeFrame == TimeframeType.Custom
                 ? new
                 {
-                    from = from.ToString("yyyy-MM-dd"),
-                    to = to.ToString("yyyy-MM-dd")
+                    from = resolved.From.ToString("yyyy-MM-dd"),
+                    to = resolved.To.ToString("yyyy-MM-dd")
                 }
                 : null,
             dataSet = new

--- a/src/azure-cost-cli.csproj
+++ b/src/azure-cost-cli.csproj
@@ -42,6 +42,10 @@
     </ItemGroup>
     
     <ItemGroup>
+      <InternalsVisibleTo Include="AzureCostCli.Tests" />
+    </ItemGroup>
+    
+    <ItemGroup>
       <Compile Remove="nupkg\**" />
     </ItemGroup>
     

--- a/tests/AzureCostCli.Tests/CostApi/ResolveTimeframeTests.cs
+++ b/tests/AzureCostCli.Tests/CostApi/ResolveTimeframeTests.cs
@@ -1,0 +1,109 @@
+using AzureCostCli.Commands;
+using AzureCostCli.CostApi;
+using Shouldly;
+using Xunit;
+
+namespace AzureCostCli.Tests.CostApi;
+
+public class ResolveTimeframeTests
+{
+    [Fact]
+    public void TheLastMonth_ReturnsCustom_WithPreviousMonthDates()
+    {
+        var today = new DateOnly(2026, 4, 14);
+        var dummyFrom = new DateOnly(2026, 1, 1);
+        var dummyTo = new DateOnly(2026, 1, 31);
+
+        var (timeFrame, from, to) = AzureCostApiRetriever.ResolveTimeframe(
+            TimeframeType.TheLastMonth, dummyFrom, dummyTo, today);
+
+        timeFrame.ShouldBe(TimeframeType.Custom);
+        from.ShouldBe(new DateOnly(2026, 3, 1));
+        to.ShouldBe(new DateOnly(2026, 3, 31));
+    }
+
+    [Fact]
+    public void TheLastBillingMonth_ReturnsCustom_WithPreviousMonthDates()
+    {
+        var today = new DateOnly(2026, 4, 14);
+        var dummyFrom = new DateOnly(2026, 1, 1);
+        var dummyTo = new DateOnly(2026, 1, 31);
+
+        var (timeFrame, from, to) = AzureCostApiRetriever.ResolveTimeframe(
+            TimeframeType.TheLastBillingMonth, dummyFrom, dummyTo, today);
+
+        timeFrame.ShouldBe(TimeframeType.Custom);
+        from.ShouldBe(new DateOnly(2026, 3, 1));
+        to.ShouldBe(new DateOnly(2026, 3, 31));
+    }
+
+    [Fact]
+    public void TheLastMonth_OnFirstDayOfMonth_ReturnsPreviousMonth()
+    {
+        var today = new DateOnly(2026, 3, 1);
+
+        var (timeFrame, from, to) = AzureCostApiRetriever.ResolveTimeframe(
+            TimeframeType.TheLastMonth, default, default, today);
+
+        timeFrame.ShouldBe(TimeframeType.Custom);
+        from.ShouldBe(new DateOnly(2026, 2, 1));
+        to.ShouldBe(new DateOnly(2026, 2, 28));
+    }
+
+    [Fact]
+    public void TheLastMonth_InJanuary_ReturnsDecemberOfPreviousYear()
+    {
+        var today = new DateOnly(2026, 1, 15);
+
+        var (timeFrame, from, to) = AzureCostApiRetriever.ResolveTimeframe(
+            TimeframeType.TheLastMonth, default, default, today);
+
+        timeFrame.ShouldBe(TimeframeType.Custom);
+        from.ShouldBe(new DateOnly(2025, 12, 1));
+        to.ShouldBe(new DateOnly(2025, 12, 31));
+    }
+
+    [Fact]
+    public void TheLastMonth_InMarch_HandlesFebruaryLeapYear()
+    {
+        var today = new DateOnly(2024, 3, 10); // 2024 is a leap year
+
+        var (timeFrame, from, to) = AzureCostApiRetriever.ResolveTimeframe(
+            TimeframeType.TheLastMonth, default, default, today);
+
+        timeFrame.ShouldBe(TimeframeType.Custom);
+        from.ShouldBe(new DateOnly(2024, 2, 1));
+        to.ShouldBe(new DateOnly(2024, 2, 29));
+    }
+
+    [Fact]
+    public void Custom_PassesThroughUnchanged()
+    {
+        var from = new DateOnly(2026, 2, 1);
+        var to = new DateOnly(2026, 2, 28);
+
+        var (timeFrame, resolvedFrom, resolvedTo) = AzureCostApiRetriever.ResolveTimeframe(
+            TimeframeType.Custom, from, to, new DateOnly(2026, 4, 14));
+
+        timeFrame.ShouldBe(TimeframeType.Custom);
+        resolvedFrom.ShouldBe(from);
+        resolvedTo.ShouldBe(to);
+    }
+
+    [Theory]
+    [InlineData(TimeframeType.MonthToDate)]
+    [InlineData(TimeframeType.BillingMonthToDate)]
+    [InlineData(TimeframeType.WeekToDate)]
+    public void OtherTimeframes_PassThroughUnchanged(TimeframeType inputTimeframe)
+    {
+        var from = new DateOnly(2026, 1, 1);
+        var to = new DateOnly(2026, 1, 31);
+
+        var (timeFrame, resolvedFrom, resolvedTo) = AzureCostApiRetriever.ResolveTimeframe(
+            inputTimeframe, from, to, new DateOnly(2026, 4, 14));
+
+        timeFrame.ShouldBe(inputTimeframe);
+        resolvedFrom.ShouldBe(from);
+        resolvedTo.ShouldBe(to);
+    }
+}


### PR DESCRIPTION
## Summary

The Azure Cost Management API no longer supports `TheLastMonth` and `TheLastBillingMonth` timeframe values, returning a 400 Bad Request error:

> `Invalid query definition, timeframe TheLastMonth is currently not supported.`

## Changes

- Added a `ResolveTimeframe` helper in `AzureCostApiRetriever` that converts deprecated timeframes into `Custom` with explicit date ranges (first to last day of the previous calendar month)
- All 8 payload-building methods now use this helper
- The CLI still accepts `-t TheLastMonth` and `-t TheLastBillingMonth` for backward compatibility — the translation is transparent
- Added `InternalsVisibleTo` for test access
- Added unit tests covering all timeframe types, edge cases (year boundary, leap year, first day of month)

## Validation

- All 251 existing tests pass
- Verified against live Azure API:
  - `accumulatedCost -t TheLastMonth` ✅ returns March 2026 data
  - `accumulatedCost -t TheLastBillingMonth` ✅ 
  - `accumulatedCost -t BillingMonthToDate` ✅ (unaffected, still works)
  - `dailyCosts -t TheLastMonth` ✅

Fixes #281