### PR TITLE
fix: skip forecast for past-only timeframes (TheLastMonth, TheLastBillingMonth)

### DIFF
--- a/src/Commands/AccumulatedCost/AccumulatedCostCommand.cs
+++ b/src/Commands/AccumulatedCost/AccumulatedCostCommand.cs
@@ -84,9 +84,8 @@ public class AccumulatedCostCommand : AsyncCommand<AccumulatedCostSettings>
                         break;
                     case TimeframeType.TheLastBillingMonth:
                     case TimeframeType.TheLastMonth:
-                        forecastStartDate =
-                            DateOnly.FromDateTime(
-                                new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1).AddMonths(-1));
+                        // These timeframes are entirely in the past; no forecast needed
+                        forecastStartDate = default;
                         break;
                     case TimeframeType.WeekToDate:
                         forecastStartDate =


### PR DESCRIPTION
When using TheLastBillingMonth or TheLastMonth timeframes, the forecast API was still being called even though these timeframes represent completed past months where forecasting is not applicable.

The Azure forecast API ignores past dates and returns forecasts starting from today. For example, when viewing April costs in May, this caused confusing output showing May forecast data in the April report.

This fix sets forecastStartDate to default for these timeframes, which skips the forecast API call entirely since the entire date range is historical.