### PR TITLE
Added No Anomalies Detected feature.

### DIFF
--- a/src/OutputFormatters/ConsoleOutputFormatter.cs
+++ b/src/OutputFormatters/ConsoleOutputFormatter.cs
@@ -549,6 +549,12 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
     public override Task WriteAnomalyDetectionResults(DetectAnomalySettings settings,
         List<AnomalyDetectionResult> anomalies)
     {
+        if (anomalies.Count == 0)
+        {
+            AnsiConsole.MarkupLine($"[green]No Anomalies Detected[/]");
+            return Task.CompletedTask;
+        }
+
         var groupedByName = anomalies.GroupBy(a => a.Name);
 
         var tree = new Tree("[red]Detected Anomalies[/]");

--- a/tests/AzureCostCli.Tests/OutputFormatters/OutputFormatterTests.cs
+++ b/tests/AzureCostCli.Tests/OutputFormatters/OutputFormatterTests.cs
@@ -1,6 +1,7 @@
 using AzureCostCli.Commands.AccumulatedCost;
 using AzureCostCli.Commands.Budgets;
 using AzureCostCli.Commands.DailyCost;
+using AzureCostCli.Commands.DetectAnomaly;
 using AzureCostCli.CostApi;
 using AzureCostCli.OutputFormatters;
 using Shouldly;
@@ -624,5 +625,27 @@ public class MarkdownOutputFormatterTests
         {
             Console.SetOut(originalOut);
         }
+    }
+}
+
+[Collection("ConsoleOutputTests")]
+public class ConsoleOutputFormatterTests
+{
+    private readonly ConsoleOutputFormatter _formatter;
+
+    public ConsoleOutputFormatterTests()
+    {
+        _formatter = new ConsoleOutputFormatter();
+    }
+
+    [Fact]
+    public async Task WriteAnomalyDetectionResults_WithNoAnomalies_ShouldNotThrow()
+    {
+        // Arrange
+        var settings = new DetectAnomalySettings();
+        var anomalies = new List<AnomalyDetectionResult>();
+
+        // Act & Assert - Should not throw
+        await _formatter.WriteAnomalyDetectionResults(settings, anomalies);
     }
 }


### PR DESCRIPTION
**Problem:**

When running detectAnomalies and no anomalies are found, the command still displays "Detected Anomalies" in red, which is confusing and misleading to users. (Especially if they are running multiple subscriptions to check.)

**Solution:**

Added a check in ConsoleOutputFormatter.WriteAnomalyDetectionResults() to display a friendly "No Anomalies Detected" message (in green) when no anomalies are found, instead of showing an empty anomaly tree with a red header.

**Tests:**

I've run this code on subscriptions with and without anomalies. 
And when not being able to authenticate to a subscription; it just throws the default error
