### PR TITLE
Bump Microsoft.NET.Test.Sdk from 18.5.1 to 18.6.0

### DIFF
--- a/src/azure-cost-cli.csproj
+++ b/src/azure-cost-cli.csproj
@@ -31,9 +31,9 @@
       <PackageReference Include="Azure.Identity" Version="1.21.0" />
       <PackageReference Include="CsvHelper" Version="33.1.0" />
       <PackageReference Include="JmesPath.Net" Version="1.1.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
-      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
       <PackageReference Include="Polly" Version="8.6.6" />
       <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
       <PackageReference Include="Spectre.Console" Version="0.55.2" />

--- a/src/azure-cost-cli.csproj
+++ b/src/azure-cost-cli.csproj
@@ -31,14 +31,14 @@
       <PackageReference Include="Azure.Identity" Version="1.21.0" />
       <PackageReference Include="CsvHelper" Version="33.1.0" />
       <PackageReference Include="JmesPath.Net" Version="1.1.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.3" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-      <PackageReference Include="Polly" Version="8.6.5" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
+      <PackageReference Include="Polly" Version="8.6.6" />
       <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-      <PackageReference Include="Spectre.Console" Version="0.55.0" />
+      <PackageReference Include="Spectre.Console" Version="0.55.2" />
       <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
-      <PackageReference Include="Spectre.Console.Json" Version="0.55.0" />
+      <PackageReference Include="Spectre.Console.Json" Version="0.55.2" />
     </ItemGroup>
     
     <ItemGroup>

--- a/tests/AzureCostCli.Tests/AzureCostCli.Tests.csproj
+++ b/tests/AzureCostCli.Tests/AzureCostCli.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/AzureCostCli.Tests/AzureCostCli.Tests.csproj
+++ b/tests/AzureCostCli.Tests/AzureCostCli.Tests.csproj
@@ -10,23 +10,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AzureCostCli.Tests/AzureCostCli.Tests.csproj
+++ b/tests/AzureCostCli.Tests/AzureCostCli.Tests.csproj
@@ -16,17 +16,17 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="10.0.0">
+    <PackageReference Include="coverlet.msbuild" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates `Microsoft.NET.Test.Sdk` from 18.5.1 to 18.6.0 in the test project.

All other packages are already at their latest versions.

**Validation:** Build succeeded, 251/251 tests passed (net10.0).