### PR TITLE
Show 'No Anomalies Detected' message when anomaly list is empty

### DIFF
--- a/src/OutputFormatters/ConsoleOutputFormatter.cs
+++ b/src/OutputFormatters/ConsoleOutputFormatter.cs
@@ -549,6 +549,12 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
     public override Task WriteAnomalyDetectionResults(DetectAnomalySettings settings,
         List<AnomalyDetectionResult> anomalies)
     {
+        if (anomalies.Count == 0)
+        {
+            AnsiConsole.MarkupLine("[green]No Anomalies Detected[/]");
+            return Task.CompletedTask;
+        }
+
         var groupedByName = anomalies.GroupBy(a => a.Name);
 
         var tree = new Tree("[red]Detected Anomalies[/]");

--- a/tests/AzureCostCli.Tests/OutputFormatters/OutputFormatterTests.cs
+++ b/tests/AzureCostCli.Tests/OutputFormatters/OutputFormatterTests.cs
@@ -647,16 +647,13 @@ public class ConsoleOutputFormatterTests
         var anomalies = new List<AnomalyDetectionResult>();
 
         // Act - capture AnsiConsole output
-        var result = await Task.Run(async () =>
-        {
-            string captured = string.Empty;
-            AnsiConsole.Record();
-            await _formatter.WriteAnomalyDetectionResults(settings, anomalies);
-            captured = AnsiConsole.ExportText();
-            return captured;
-        });
+        AnsiConsole.Record();
+        await _formatter.WriteAnomalyDetectionResults(settings, anomalies);
+        var result = AnsiConsole.ExportText();
 
-        // Assert
+        // Assert - friendly message shown, confusing red header is absent
         result.ShouldContain("No Anomalies Detected");
+        result.ShouldNotContain("Detected Anomalies");
     }
 }
+

--- a/tests/AzureCostCli.Tests/OutputFormatters/OutputFormatterTests.cs
+++ b/tests/AzureCostCli.Tests/OutputFormatters/OutputFormatterTests.cs
@@ -1,6 +1,7 @@
 using AzureCostCli.Commands.AccumulatedCost;
 using AzureCostCli.Commands.Budgets;
 using AzureCostCli.Commands.DailyCost;
+using AzureCostCli.Commands.DetectAnomaly;
 using AzureCostCli.CostApi;
 using AzureCostCli.OutputFormatters;
 using Shouldly;
@@ -8,6 +9,7 @@ using System.Text.Json;
 using CsvHelper;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using Spectre.Console;
 using Xunit;
 
 namespace AzureCostCli.Tests.OutputFormatters;
@@ -624,5 +626,37 @@ public class MarkdownOutputFormatterTests
         {
             Console.SetOut(originalOut);
         }
+    }
+}
+
+[Collection("ConsoleOutputTests")]
+public class ConsoleOutputFormatterTests
+{
+    private readonly ConsoleOutputFormatter _formatter;
+
+    public ConsoleOutputFormatterTests()
+    {
+        _formatter = new ConsoleOutputFormatter();
+    }
+
+    [Fact]
+    public async Task WriteAnomalyDetectionResults_WithNoAnomalies_WritesNoAnomaliesMessage()
+    {
+        // Arrange
+        var settings = new DetectAnomalySettings();
+        var anomalies = new List<AnomalyDetectionResult>();
+
+        // Act - capture AnsiConsole output
+        var result = await Task.Run(async () =>
+        {
+            string captured = string.Empty;
+            AnsiConsole.Record();
+            await _formatter.WriteAnomalyDetectionResults(settings, anomalies);
+            captured = AnsiConsole.ExportText();
+            return captured;
+        });
+
+        // Assert
+        result.ShouldContain("No Anomalies Detected");
     }
 }


### PR DESCRIPTION
**Problem:**

When running `detectAnomalies` and no anomalies are found, the command displayed a confusing red "Detected Anomalies" header with nothing beneath it.

**Solution:**

Added an early-return in `ConsoleOutputFormatter.WriteAnomalyDetectionResults()` that displays a friendly green "No Anomalies Detected" message when the list is empty.

**Changes over the original PR #320:**
- Removed spurious string interpolation (`$"..."` → `"..."`) since no interpolated values were used
- Strengthened the test to actually capture and assert on `AnsiConsole` output (not just assert no exception)
- Added missing newline at end of test file

**Tests:** 252/252 passing (net10.0).

Closes #320