### PR TITLE
feat: cost threshold alerting commands for CI/CD gating

### DIFF
--- a/src/Commands/Threshold/BaseThresholdCommand.cs
+++ b/src/Commands/Threshold/BaseThresholdCommand.cs
@@ -1,0 +1,46 @@
+using AzureCostCli.CostApi;
+using AzureCostCli.OutputFormatters;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace AzureCostCli.Commands.Threshold;
+
+/// <summary>
+/// Abstract base class for all threshold sub-commands. Handles common validation and setup.
+/// </summary>
+public abstract class BaseThresholdCommand<TSettings> : AsyncCommand<TSettings>
+    where TSettings : ThresholdSettings
+{
+    protected readonly ICostRetriever CostRetriever;
+    protected readonly Dictionary<OutputFormat, BaseOutputFormatter> OutputFormatters =
+        OutputFormatterFactory.Create();
+
+    protected BaseThresholdCommand(ICostRetriever costRetriever)
+    {
+        CostRetriever = costRetriever;
+    }
+
+    protected override ValidationResult Validate(CommandContext context, TSettings settings)
+    {
+        var subResult = CommandHelpers.ValidateAndResolveSubscription(
+            settings.Subscription, settings.GetScope.IsSubscriptionBased,
+            id => settings.Subscription = id);
+        if (!subResult.Successful) return subResult;
+
+        if (settings.Percentage == null && settings.FixedAmount == null)
+            return ValidationResult.Error(
+                "At least one threshold must be specified: --percentage or --fixed-amount.");
+
+        return CommandHelpers.ValidateTimeframe(settings);
+    }
+
+    protected bool IsExceeded(double change, double? absoluteChange, ThresholdSettings settings)
+    {
+        if (settings.Percentage.HasValue && Math.Abs(change) > settings.Percentage.Value)
+            return true;
+        if (settings.FixedAmount.HasValue && absoluteChange.HasValue &&
+            Math.Abs(absoluteChange.Value) > settings.FixedAmount.Value)
+            return true;
+        return false;
+    }
+}

--- a/src/Commands/Threshold/DailyChangeThresholdCommand.cs
+++ b/src/Commands/Threshold/DailyChangeThresholdCommand.cs
@@ -32,7 +32,7 @@ public class DailyChangeThresholdCommand : BaseThresholdCommand<ThresholdSetting
             yesterday,
             today)).ToList();
 
-        var currency = costs.FirstOrDefault()?.Currency ?? "USD";
+        var currency = settings.UseUSD ? "USD" : (costs.FirstOrDefault()?.Currency ?? "USD");
 
         var todayCost = costs.Where(c => c.Date == today).Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
         var yesterdayCost = costs.Where(c => c.Date == yesterday).Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
@@ -48,7 +48,9 @@ public class DailyChangeThresholdCommand : BaseThresholdCommand<ThresholdSetting
             ? $"Daily cost change exceeds threshold: today={todayCost:N2} {currency}, yesterday={yesterdayCost:N2} {currency}, change={changeAbs:+0.00;-0.00} ({changePct:+0.0;-0.0}%)"
             : $"Daily cost change within threshold: today={todayCost:N2} {currency}, yesterday={yesterdayCost:N2} {currency}, change={changeAbs:+0.00;-0.00} ({changePct:+0.0;-0.0}%)";
 
-        var result = new ThresholdResult("daily-change", exceeded, changePct, settings.Percentage ?? settings.FixedAmount, message);
+        double actualValue = settings.Percentage.HasValue ? changePct : changeAbs;
+
+        var result = new ThresholdResult("daily-change", exceeded, actualValue, settings.Percentage ?? settings.FixedAmount, message);
 
         await OutputFormatters[settings.Output].WriteThreshold(settings, result);
 

--- a/src/Commands/Threshold/DailyChangeThresholdCommand.cs
+++ b/src/Commands/Threshold/DailyChangeThresholdCommand.cs
@@ -1,0 +1,57 @@
+using AzureCostCli.CostApi;
+using AzureCostCli.OutputFormatters;
+using Spectre.Console.Cli;
+
+namespace AzureCostCli.Commands.Threshold;
+
+/// <summary>
+/// Compares today's total cost to yesterday's. Triggers if the change (absolute or %)
+/// exceeds the configured threshold.
+/// </summary>
+public class DailyChangeThresholdCommand : BaseThresholdCommand<ThresholdSettings>
+{
+    public DailyChangeThresholdCommand(ICostRetriever costRetriever) : base(costRetriever) { }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, ThresholdSettings settings,
+        CancellationToken cancellationToken)
+    {
+        CommandHelpers.PrintVersionIfDebug(settings.Debug);
+        CostRetriever.CostApiAddress = settings.CostApiAddress;
+        CostRetriever.HttpTimeout = TimeSpan.FromSeconds(settings.HttpTimeout);
+
+        // Fetch daily costs for the last two days
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var yesterday = today.AddDays(-1);
+
+        var costs = (await CostRetriever.RetrieveCosts(
+            settings.Debug,
+            settings.GetScope,
+            settings.Filter,
+            settings.Metric,
+            TimeframeType.Custom,
+            yesterday,
+            today)).ToList();
+
+        var currency = costs.FirstOrDefault()?.Currency ?? "USD";
+
+        var todayCost = costs.Where(c => c.Date == today).Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
+        var yesterdayCost = costs.Where(c => c.Date == yesterday).Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
+
+        double changePct = yesterdayCost == 0
+            ? (todayCost > 0 ? 100.0 : 0.0)
+            : (todayCost - yesterdayCost) / yesterdayCost * 100.0;
+        double changeAbs = todayCost - yesterdayCost;
+
+        bool exceeded = IsExceeded(changePct, changeAbs, settings);
+
+        var message = exceeded
+            ? $"Daily cost change exceeds threshold: today={todayCost:N2} {currency}, yesterday={yesterdayCost:N2} {currency}, change={changeAbs:+0.00;-0.00} ({changePct:+0.0;-0.0}%)"
+            : $"Daily cost change within threshold: today={todayCost:N2} {currency}, yesterday={yesterdayCost:N2} {currency}, change={changeAbs:+0.00;-0.00} ({changePct:+0.0;-0.0}%)";
+
+        var result = new ThresholdResult("daily-change", exceeded, changePct, settings.Percentage ?? settings.FixedAmount, message);
+
+        await OutputFormatters[settings.Output].WriteThreshold(settings, result);
+
+        return settings.FailOnThreshold && exceeded ? 1 : 0;
+    }
+}

--- a/src/Commands/Threshold/ForecastDeviationThresholdCommand.cs
+++ b/src/Commands/Threshold/ForecastDeviationThresholdCommand.cs
@@ -30,9 +30,9 @@ public class ForecastDeviationThresholdCommand : BaseThresholdCommand<ThresholdS
             settings.Debug, settings.GetScope, settings.Filter, settings.Metric,
             settings.Timeframe, from, to)).ToList();
 
-        var currency = actualCosts.FirstOrDefault()?.Currency
+        var currency = settings.UseUSD ? "USD" : (actualCosts.FirstOrDefault()?.Currency
                        ?? forecastedCosts.FirstOrDefault()?.Currency
-                       ?? "USD";
+                       ?? "USD");
 
         var actual = actualCosts.Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
         var forecast = forecastedCosts.Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
@@ -48,7 +48,9 @@ public class ForecastDeviationThresholdCommand : BaseThresholdCommand<ThresholdS
             ? $"Forecast deviation exceeds threshold: actual={actual:N2} {currency}, forecast={forecast:N2} {currency}, deviation={deviationAbs:+0.00;-0.00} ({deviationPct:+0.0;-0.0}%)"
             : $"Forecast deviation within threshold: actual={actual:N2} {currency}, forecast={forecast:N2} {currency}, deviation={deviationAbs:+0.00;-0.00} ({deviationPct:+0.0;-0.0}%)";
 
-        var result = new ThresholdResult("forecast-deviation", exceeded, deviationPct, settings.Percentage ?? settings.FixedAmount, message);
+        double actualValue = settings.Percentage.HasValue ? deviationPct : deviationAbs;
+
+        var result = new ThresholdResult("forecast-deviation", exceeded, actualValue, settings.Percentage ?? settings.FixedAmount, message);
 
         await OutputFormatters[settings.Output].WriteThreshold(settings, result);
 

--- a/src/Commands/Threshold/ForecastDeviationThresholdCommand.cs
+++ b/src/Commands/Threshold/ForecastDeviationThresholdCommand.cs
@@ -1,0 +1,57 @@
+using AzureCostCli.CostApi;
+using AzureCostCli.OutputFormatters;
+using Spectre.Console.Cli;
+
+namespace AzureCostCli.Commands.Threshold;
+
+/// <summary>
+/// Compares actual spend to forecasted spend. Triggers if actual deviates from forecast
+/// by more than the configured threshold.
+/// </summary>
+public class ForecastDeviationThresholdCommand : BaseThresholdCommand<ThresholdSettings>
+{
+    public ForecastDeviationThresholdCommand(ICostRetriever costRetriever) : base(costRetriever) { }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, ThresholdSettings settings,
+        CancellationToken cancellationToken)
+    {
+        CommandHelpers.PrintVersionIfDebug(settings.Debug);
+        CostRetriever.CostApiAddress = settings.CostApiAddress;
+        CostRetriever.HttpTimeout = TimeSpan.FromSeconds(settings.HttpTimeout);
+
+        var from = settings.GetFromDate();
+        var to = settings.GetToDate();
+
+        var actualCosts = (await CostRetriever.RetrieveCosts(
+            settings.Debug, settings.GetScope, settings.Filter, settings.Metric,
+            settings.Timeframe, from, to)).ToList();
+
+        var forecastedCosts = (await CostRetriever.RetrieveForecastedCosts(
+            settings.Debug, settings.GetScope, settings.Filter, settings.Metric,
+            settings.Timeframe, from, to)).ToList();
+
+        var currency = actualCosts.FirstOrDefault()?.Currency
+                       ?? forecastedCosts.FirstOrDefault()?.Currency
+                       ?? "USD";
+
+        var actual = actualCosts.Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
+        var forecast = forecastedCosts.Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
+
+        double deviationPct = forecast == 0
+            ? (actual > 0 ? 100.0 : 0.0)
+            : (actual - forecast) / forecast * 100.0;
+        double deviationAbs = actual - forecast;
+
+        bool exceeded = IsExceeded(deviationPct, deviationAbs, settings);
+
+        var message = exceeded
+            ? $"Forecast deviation exceeds threshold: actual={actual:N2} {currency}, forecast={forecast:N2} {currency}, deviation={deviationAbs:+0.00;-0.00} ({deviationPct:+0.0;-0.0}%)"
+            : $"Forecast deviation within threshold: actual={actual:N2} {currency}, forecast={forecast:N2} {currency}, deviation={deviationAbs:+0.00;-0.00} ({deviationPct:+0.0;-0.0}%)";
+
+        var result = new ThresholdResult("forecast-deviation", exceeded, deviationPct, settings.Percentage ?? settings.FixedAmount, message);
+
+        await OutputFormatters[settings.Output].WriteThreshold(settings, result);
+
+        return settings.FailOnThreshold && exceeded ? 1 : 0;
+    }
+}

--- a/src/Commands/Threshold/ServiceSpikeThresholdCommand.cs
+++ b/src/Commands/Threshold/ServiceSpikeThresholdCommand.cs
@@ -1,0 +1,80 @@
+using AzureCostCli.CostApi;
+using AzureCostCli.OutputFormatters;
+using Spectre.Console.Cli;
+
+namespace AzureCostCli.Commands.Threshold;
+
+/// <summary>
+/// Loops through cost-by-service, comparing current period to previous period.
+/// Triggers if any single service cost exceeds the threshold.
+/// </summary>
+public class ServiceSpikeThresholdCommand : BaseThresholdCommand<ThresholdSettings>
+{
+    public ServiceSpikeThresholdCommand(ICostRetriever costRetriever) : base(costRetriever) { }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, ThresholdSettings settings,
+        CancellationToken cancellationToken)
+    {
+        CommandHelpers.PrintVersionIfDebug(settings.Debug);
+        CostRetriever.CostApiAddress = settings.CostApiAddress;
+        CostRetriever.HttpTimeout = TimeSpan.FromSeconds(settings.HttpTimeout);
+
+        var to = settings.GetToDate();
+        var from = settings.GetFromDate();
+        var periodLength = (to.DayNumber - from.DayNumber) + 1;
+
+        // Previous period of same length
+        var prevTo = from.AddDays(-1);
+        var prevFrom = prevTo.AddDays(-(periodLength - 1));
+
+        var currentServices = (await CostRetriever.RetrieveCostByServiceName(
+            settings.Debug, settings.GetScope, settings.Filter, settings.Metric,
+            TimeframeType.Custom, from, to)).ToList();
+
+        var previousServices = (await CostRetriever.RetrieveCostByServiceName(
+            settings.Debug, settings.GetScope, settings.Filter, settings.Metric,
+            TimeframeType.Custom, prevFrom, prevTo)).ToList();
+
+        var currency = currentServices.FirstOrDefault()?.Currency
+                       ?? previousServices.FirstOrDefault()?.Currency
+                       ?? "USD";
+
+        // Find the biggest spike across all services
+        var spikedService = string.Empty;
+        double maxChangePct = 0;
+        double maxChangeAbs = 0;
+
+        foreach (var svc in currentServices)
+        {
+            var curr = settings.UseUSD ? svc.CostUsd : svc.Cost;
+            var prev = previousServices.FirstOrDefault(p => p.ItemName == svc.ItemName);
+            var prevCost = prev == null ? 0 : (settings.UseUSD ? prev.CostUsd : prev.Cost);
+
+            double pct = prevCost == 0
+                ? (curr > 0 ? 100.0 : 0.0)
+                : (curr - prevCost) / prevCost * 100.0;
+            double abs = curr - prevCost;
+
+            if (Math.Abs(pct) > Math.Abs(maxChangePct))
+            {
+                maxChangePct = pct;
+                maxChangeAbs = abs;
+                spikedService = svc.ItemName;
+            }
+        }
+
+        bool exceeded = !string.IsNullOrEmpty(spikedService) && IsExceeded(maxChangePct, maxChangeAbs, settings);
+
+        var message = exceeded
+            ? $"Service spike detected for '{spikedService}': change={maxChangeAbs:+0.00;-0.00} {currency} ({maxChangePct:+0.0;-0.0}%)"
+            : string.IsNullOrEmpty(spikedService)
+                ? "No service cost data found for comparison."
+                : $"No service spike detected (max change: '{spikedService}' {maxChangeAbs:+0.00;-0.00} {currency} ({maxChangePct:+0.0;-0.0}%))";
+
+        var result = new ThresholdResult("service-spike", exceeded, maxChangePct, settings.Percentage ?? settings.FixedAmount, message);
+
+        await OutputFormatters[settings.Output].WriteThreshold(settings, result);
+
+        return settings.FailOnThreshold && exceeded ? 1 : 0;
+    }
+}

--- a/src/Commands/Threshold/ServiceSpikeThresholdCommand.cs
+++ b/src/Commands/Threshold/ServiceSpikeThresholdCommand.cs
@@ -35,14 +35,16 @@ public class ServiceSpikeThresholdCommand : BaseThresholdCommand<ThresholdSettin
             settings.Debug, settings.GetScope, settings.Filter, settings.Metric,
             TimeframeType.Custom, prevFrom, prevTo)).ToList();
 
-        var currency = currentServices.FirstOrDefault()?.Currency
+        var currency = settings.UseUSD ? "USD" : (currentServices.FirstOrDefault()?.Currency
                        ?? previousServices.FirstOrDefault()?.Currency
-                       ?? "USD";
+                       ?? "USD");
 
-        // Find the biggest spike across all services
+        // Check every service; exceeded if any service breaches the threshold.
+        // Among all breaching services (or all services if none breach) track the worst by abs change.
         var spikedService = string.Empty;
         double maxChangePct = 0;
         double maxChangeAbs = 0;
+        bool exceeded = false;
 
         foreach (var svc in currentServices)
         {
@@ -55,7 +57,13 @@ public class ServiceSpikeThresholdCommand : BaseThresholdCommand<ThresholdSettin
                 : (curr - prevCost) / prevCost * 100.0;
             double abs = curr - prevCost;
 
-            if (Math.Abs(pct) > Math.Abs(maxChangePct))
+            bool svcExceeded = IsExceeded(pct, abs, settings);
+            if (svcExceeded) exceeded = true;
+
+            // Report the service with the largest absolute change among all that exceeded;
+            // if none exceeded yet, track the worst overall so we can report it in the OK message.
+            if (svcExceeded && Math.Abs(abs) > Math.Abs(maxChangeAbs) ||
+                !exceeded && Math.Abs(pct) > Math.Abs(maxChangePct))
             {
                 maxChangePct = pct;
                 maxChangeAbs = abs;
@@ -63,7 +71,7 @@ public class ServiceSpikeThresholdCommand : BaseThresholdCommand<ThresholdSettin
             }
         }
 
-        bool exceeded = !string.IsNullOrEmpty(spikedService) && IsExceeded(maxChangePct, maxChangeAbs, settings);
+        double actualValue = settings.Percentage.HasValue ? maxChangePct : maxChangeAbs;
 
         var message = exceeded
             ? $"Service spike detected for '{spikedService}': change={maxChangeAbs:+0.00;-0.00} {currency} ({maxChangePct:+0.0;-0.0}%)"
@@ -71,7 +79,7 @@ public class ServiceSpikeThresholdCommand : BaseThresholdCommand<ThresholdSettin
                 ? "No service cost data found for comparison."
                 : $"No service spike detected (max change: '{spikedService}' {maxChangeAbs:+0.00;-0.00} {currency} ({maxChangePct:+0.0;-0.0}%))";
 
-        var result = new ThresholdResult("service-spike", exceeded, maxChangePct, settings.Percentage ?? settings.FixedAmount, message);
+        var result = new ThresholdResult("service-spike", exceeded, actualValue, settings.Percentage ?? settings.FixedAmount, message);
 
         await OutputFormatters[settings.Output].WriteThreshold(settings, result);
 

--- a/src/Commands/Threshold/ThresholdResult.cs
+++ b/src/Commands/Threshold/ThresholdResult.cs
@@ -1,0 +1,8 @@
+namespace AzureCostCli.Commands.Threshold;
+
+public record ThresholdResult(
+    string SubCommand,
+    bool IsThresholdExceeded,
+    double? ActualValue,
+    double? ThresholdValue,
+    string Message);

--- a/src/Commands/Threshold/ThresholdSettings.cs
+++ b/src/Commands/Threshold/ThresholdSettings.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+using Spectre.Console.Cli;
+
+namespace AzureCostCli.Commands.Threshold;
+
+public class ThresholdSettings : CostSettings
+{
+    [CommandOption("--percentage")]
+    [Description("Trigger the threshold if the change or deviation exceeds this percentage. E.g. 20 means 20%.")]
+    public double? Percentage { get; set; }
+
+    [CommandOption("--fixed-amount")]
+    [Description("Trigger the threshold if the change or deviation exceeds this fixed monetary amount.")]
+    public double? FixedAmount { get; set; }
+
+    [CommandOption("--fail-on-threshold")]
+    [Description("Return exit code 1 when the threshold is exceeded. Useful for failing CI/CD pipelines. Defaults to false.")]
+    [DefaultValue(false)]
+    public bool FailOnThreshold { get; set; }
+}

--- a/src/Commands/Threshold/WeeklyAverageThresholdCommand.cs
+++ b/src/Commands/Threshold/WeeklyAverageThresholdCommand.cs
@@ -1,0 +1,55 @@
+using AzureCostCli.CostApi;
+using AzureCostCli.OutputFormatters;
+using Spectre.Console.Cli;
+
+namespace AzureCostCli.Commands.Threshold;
+
+/// <summary>
+/// Computes the last 7 days average daily cost and triggers if it exceeds the threshold.
+/// </summary>
+public class WeeklyAverageThresholdCommand : BaseThresholdCommand<ThresholdSettings>
+{
+    public WeeklyAverageThresholdCommand(ICostRetriever costRetriever) : base(costRetriever) { }
+
+    protected override async Task<int> ExecuteAsync(CommandContext context, ThresholdSettings settings,
+        CancellationToken cancellationToken)
+    {
+        CommandHelpers.PrintVersionIfDebug(settings.Debug);
+        CostRetriever.CostApiAddress = settings.CostApiAddress;
+        CostRetriever.HttpTimeout = TimeSpan.FromSeconds(settings.HttpTimeout);
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var sevenDaysAgo = today.AddDays(-6); // inclusive last 7 days
+
+        var costs = (await CostRetriever.RetrieveCosts(
+            settings.Debug, settings.GetScope, settings.Filter, settings.Metric,
+            TimeframeType.Custom, sevenDaysAgo, today)).ToList();
+
+        var currency = costs.FirstOrDefault()?.Currency ?? "USD";
+
+        var total = costs.Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
+        var average = costs.Count > 0 ? total / 7.0 : 0.0;
+
+        // For weekly-average we compare the average against the fixed-amount threshold directly,
+        // or use percentage as a ratio above zero (i.e. any non-zero average triggers if % is 0).
+        // Semantics: exceeded if average > fixed-amount, or if percentage threshold is set,
+        // we use it as the absolute percentage of average growth vs the threshold value directly.
+        bool exceeded = false;
+        if (settings.FixedAmount.HasValue && average > settings.FixedAmount.Value)
+            exceeded = true;
+        if (settings.Percentage.HasValue && average > settings.Percentage.Value)
+            exceeded = true;
+
+        var thresholdValue = settings.FixedAmount ?? settings.Percentage;
+
+        var message = exceeded
+            ? $"Weekly average daily cost exceeds threshold: average={average:N2} {currency}/day (total={total:N2} {currency} over 7 days), threshold={thresholdValue:N2}"
+            : $"Weekly average daily cost within threshold: average={average:N2} {currency}/day (total={total:N2} {currency} over 7 days)";
+
+        var result = new ThresholdResult("weekly-average", exceeded, average, thresholdValue, message);
+
+        await OutputFormatters[settings.Output].WriteThreshold(settings, result);
+
+        return settings.FailOnThreshold && exceeded ? 1 : 0;
+    }
+}

--- a/src/Commands/Threshold/WeeklyAverageThresholdCommand.cs
+++ b/src/Commands/Threshold/WeeklyAverageThresholdCommand.cs
@@ -1,5 +1,6 @@
 using AzureCostCli.CostApi;
 using AzureCostCli.OutputFormatters;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace AzureCostCli.Commands.Threshold;
@@ -10,6 +11,15 @@ namespace AzureCostCli.Commands.Threshold;
 public class WeeklyAverageThresholdCommand : BaseThresholdCommand<ThresholdSettings>
 {
     public WeeklyAverageThresholdCommand(ICostRetriever costRetriever) : base(costRetriever) { }
+
+    protected override ValidationResult Validate(CommandContext context, ThresholdSettings settings)
+    {
+        if (settings.Percentage.HasValue)
+            return ValidationResult.Error(
+                "The weekly-average command does not support --percentage. " +
+                "Use --fixed-amount to specify a monetary threshold.");
+        return base.Validate(context, settings);
+    }
 
     protected override async Task<int> ExecuteAsync(CommandContext context, ThresholdSettings settings,
         CancellationToken cancellationToken)
@@ -25,20 +35,13 @@ public class WeeklyAverageThresholdCommand : BaseThresholdCommand<ThresholdSetti
             settings.Debug, settings.GetScope, settings.Filter, settings.Metric,
             TimeframeType.Custom, sevenDaysAgo, today)).ToList();
 
-        var currency = costs.FirstOrDefault()?.Currency ?? "USD";
+        var currency = settings.UseUSD ? "USD" : (costs.FirstOrDefault()?.Currency ?? "USD");
 
         var total = costs.Sum(c => settings.UseUSD ? c.CostUsd : c.Cost);
         var average = costs.Count > 0 ? total / 7.0 : 0.0;
 
-        // For weekly-average we compare the average against the fixed-amount threshold directly,
-        // or use percentage as a ratio above zero (i.e. any non-zero average triggers if % is 0).
-        // Semantics: exceeded if average > fixed-amount, or if percentage threshold is set,
-        // we use it as the absolute percentage of average growth vs the threshold value directly.
-        bool exceeded = false;
-        if (settings.FixedAmount.HasValue && average > settings.FixedAmount.Value)
-            exceeded = true;
-        if (settings.Percentage.HasValue && average > settings.Percentage.Value)
-            exceeded = true;
+        // Only --fixed-amount is supported; --percentage is rejected in Validate.
+        bool exceeded = settings.FixedAmount.HasValue && average > settings.FixedAmount.Value;
 
         var thresholdValue = settings.FixedAmount ?? settings.Percentage;
 

--- a/src/OutputFormatters/BaseOutputFormatter.cs
+++ b/src/OutputFormatters/BaseOutputFormatter.cs
@@ -6,6 +6,7 @@ using AzureCostCli.Commands.DailyCost;
 using AzureCostCli.Commands.DetectAnomaly;
 using AzureCostCli.Commands.Diff;
 using AzureCostCli.Commands.Regions;
+using AzureCostCli.Commands.Threshold;
 using AzureCostCli.Commands.WhatIf;
 using AzureCostCli.CostApi;
 
@@ -28,6 +29,8 @@ public abstract class BaseOutputFormatter
     public abstract Task WriteDevTestComparison(WhatIfSettings settings, IEnumerable<DevTestComparisonItem> items);
     public abstract Task WriteAccumulatedDiffCost(DiffSettings settings, AccumulatedCostDetails accumulatedCostSource,
         AccumulatedCostDetails accumulatedCostTarget);
+
+    public abstract Task WriteThreshold(ThresholdSettings settings, ThresholdResult result);
 
 }
 

--- a/src/OutputFormatters/ConsoleOutputFormatter.cs
+++ b/src/OutputFormatters/ConsoleOutputFormatter.cs
@@ -8,6 +8,7 @@ using AzureCostCli.Commands.DailyCost;
 using AzureCostCli.Commands.DetectAnomaly;
 using AzureCostCli.Commands.Diff;
 using AzureCostCli.Commands.Regions;
+using AzureCostCli.Commands.Threshold;
 using AzureCostCli.Commands.WhatIf;
 using AzureCostCli.CostApi;
 using AzureCostCli.Infrastructure;
@@ -1027,5 +1028,31 @@ public class ConsoleOutputFormatter : BaseOutputFormatter
             $"[bold]{Money.FormatMoney(totalTarget, currency)}[/]",
             totalDiffFormatted
         );
+    }
+
+    public override Task WriteThreshold(ThresholdSettings settings, ThresholdResult result)
+    {
+        var statusColor = result.IsThresholdExceeded ? "red" : "green";
+        var statusLabel = result.IsThresholdExceeded ? "EXCEEDED" : "OK";
+        var icon = result.IsThresholdExceeded ? ":red_circle:" : ":green_circle:";
+
+        var table = new Table()
+            .RoundedBorder()
+            .Expand()
+            .Title($"Threshold Check: [bold]{result.SubCommand}[/]")
+            .AddColumn("Field")
+            .AddColumn("Value");
+
+        table.AddRow("Status", $"[{statusColor} bold]{icon} {statusLabel}[/]");
+        table.AddRow("Sub-command", result.SubCommand);
+        table.AddRow("Message", result.Message.EscapeMarkup());
+        if (result.ActualValue.HasValue)
+            table.AddRow("Actual value", $"{result.ActualValue.Value:N2}");
+        if (result.ThresholdValue.HasValue)
+            table.AddRow("Threshold", $"{result.ThresholdValue.Value:N2}");
+
+        AnsiConsole.Write(table);
+
+        return Task.CompletedTask;
     }
 }

--- a/src/OutputFormatters/CsvOutputFormatter.cs
+++ b/src/OutputFormatters/CsvOutputFormatter.cs
@@ -8,6 +8,7 @@ using AzureCostCli.Commands.DailyCost;
 using AzureCostCli.Commands.DetectAnomaly;
 using AzureCostCli.Commands.Diff;
 using AzureCostCli.Commands.Regions;
+using AzureCostCli.Commands.Threshold;
 using AzureCostCli.Commands.WhatIf;
 using AzureCostCli.CostApi;
 using CsvHelper;
@@ -256,6 +257,26 @@ public class CsvOutputFormatter : BaseOutputFormatter
             Console.Write(writer.ToString());
         }
 
+        return Task.CompletedTask;
+    }
+
+    public override Task WriteThreshold(ThresholdSettings settings, ThresholdResult result)
+    {
+        using var writer = new StringWriter();
+        using var csv = new CsvWriter(writer, new CsvHelper.Configuration.CsvConfiguration(CultureInfo.InvariantCulture));
+        csv.WriteField("SubCommand");
+        csv.WriteField("IsThresholdExceeded");
+        csv.WriteField("ActualValue");
+        csv.WriteField("ThresholdValue");
+        csv.WriteField("Message");
+        csv.NextRecord();
+        csv.WriteField(result.SubCommand);
+        csv.WriteField(result.IsThresholdExceeded);
+        csv.WriteField(result.ActualValue?.ToString("F4", CultureInfo.InvariantCulture) ?? "");
+        csv.WriteField(result.ThresholdValue?.ToString("F4", CultureInfo.InvariantCulture) ?? "");
+        csv.WriteField(result.Message);
+        csv.NextRecord();
+        Console.Write(writer.ToString());
         return Task.CompletedTask;
     }
 }

--- a/src/OutputFormatters/JsonOutputFormatter.cs
+++ b/src/OutputFormatters/JsonOutputFormatter.cs
@@ -9,6 +9,7 @@ using AzureCostCli.Commands.DailyCost;
 using AzureCostCli.Commands.DetectAnomaly;
 using AzureCostCli.Commands.Diff;
 using AzureCostCli.Commands.Regions;
+using AzureCostCli.Commands.Threshold;
 using AzureCostCli.Commands.WhatIf;
 using AzureCostCli.CostApi;
 using DevLab.JmesPath;
@@ -131,6 +132,12 @@ public class JsonOutputFormatter : BaseOutputFormatter
     public override Task WriteDevTestComparison(WhatIfSettings settings, IEnumerable<DevTestComparisonItem> items)
     {
         WriteJson(settings, items);
+        return Task.CompletedTask;
+    }
+
+    public override Task WriteThreshold(ThresholdSettings settings, ThresholdResult result)
+    {
+        WriteJson(settings, result);
         return Task.CompletedTask;
     }
     

--- a/src/OutputFormatters/MarkdownOutputFormatter.cs
+++ b/src/OutputFormatters/MarkdownOutputFormatter.cs
@@ -666,7 +666,7 @@ public class MarkdownOutputFormatter : BaseOutputFormatter
         Console.WriteLine($"| Field | Value |");
         Console.WriteLine($"|-------|-------|");
         Console.WriteLine($"| Sub-command | `{result.SubCommand}` |");
-        Console.WriteLine($"| Message | {result.Message} |");
+        Console.WriteLine($"| Message | {result.Message.Replace("|", "\\|").Replace("\r\n", " ").Replace("\n", " ")} |");
         if (result.ActualValue.HasValue)
             Console.WriteLine($"| Actual value | {result.ActualValue.Value:N2} |");
         if (result.ThresholdValue.HasValue)

--- a/src/OutputFormatters/MarkdownOutputFormatter.cs
+++ b/src/OutputFormatters/MarkdownOutputFormatter.cs
@@ -8,6 +8,7 @@ using AzureCostCli.Commands.DailyCost;
 using AzureCostCli.Commands.DetectAnomaly;
 using AzureCostCli.Commands.Diff;
 using AzureCostCli.Commands.Regions;
+using AzureCostCli.Commands.Threshold;
 using AzureCostCli.Commands.WhatIf;
 using AzureCostCli.CostApi;
 using AzureCostCli.Infrastructure;
@@ -651,6 +652,26 @@ public class MarkdownOutputFormatter : BaseOutputFormatter
         Console.WriteLine($"**Total DevTest Cost:** {totalDevTest:N2} {currency}  ");
         Console.WriteLine($"**Total Savings:** {totalSavings:N2} {currency} ({(totalCurrent > 0 ? totalSavings / totalCurrent * 100 : 0):N1}%)");
 
+        return Task.CompletedTask;
+    }
+
+    public override Task WriteThreshold(ThresholdSettings settings, ThresholdResult result)
+    {
+        var status = result.IsThresholdExceeded ? "EXCEEDED" : "OK";
+        var emoji = result.IsThresholdExceeded ? ":x:" : ":white_check_mark:";
+        Console.WriteLine($"## Threshold Check: `{result.SubCommand}`");
+        Console.WriteLine();
+        Console.WriteLine($"**Status:** {emoji} **{status}**");
+        Console.WriteLine();
+        Console.WriteLine($"| Field | Value |");
+        Console.WriteLine($"|-------|-------|");
+        Console.WriteLine($"| Sub-command | `{result.SubCommand}` |");
+        Console.WriteLine($"| Message | {result.Message} |");
+        if (result.ActualValue.HasValue)
+            Console.WriteLine($"| Actual value | {result.ActualValue.Value:N2} |");
+        if (result.ThresholdValue.HasValue)
+            Console.WriteLine($"| Threshold | {result.ThresholdValue.Value:N2} |");
+        Console.WriteLine();
         return Task.CompletedTask;
     }
 }

--- a/src/OutputFormatters/TextOutputFormatter.cs
+++ b/src/OutputFormatters/TextOutputFormatter.cs
@@ -7,6 +7,7 @@ using AzureCostCli.Commands.DailyCost;
 using AzureCostCli.Commands.DetectAnomaly;
 using AzureCostCli.Commands.Diff;
 using AzureCostCli.Commands.Regions;
+using AzureCostCli.Commands.Threshold;
 using AzureCostCli.Commands.WhatIf;
 using AzureCostCli.CostApi;
 using AzureCostCli.Infrastructure;
@@ -468,6 +469,18 @@ public class TextOutputFormatter : BaseOutputFormatter
         Console.WriteLine($"Total DevTest Cost: {totalDevTest:N2} {currency}");
         Console.WriteLine($"Total Savings: {totalSavings:N2} {currency} ({(totalCurrent > 0 ? totalSavings / totalCurrent * 100 : 0):N1}%)");
 
+        return Task.CompletedTask;
+    }
+
+    public override Task WriteThreshold(ThresholdSettings settings, ThresholdResult result)
+    {
+        var status = result.IsThresholdExceeded ? "EXCEEDED" : "OK";
+        Console.WriteLine($"Threshold Check [{result.SubCommand}]: {status}");
+        Console.WriteLine($"  {result.Message}");
+        if (result.ActualValue.HasValue)
+            Console.WriteLine($"  Actual value: {result.ActualValue.Value:N2}");
+        if (result.ThresholdValue.HasValue)
+            Console.WriteLine($"  Threshold: {result.ThresholdValue.Value:N2}");
         return Task.CompletedTask;
     }
     

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -9,6 +9,7 @@ using AzureCostCli.Commands.DailyCost;
 using AzureCostCli.Commands.DetectAnomaly;
 using AzureCostCli.Commands.Diff;
 using AzureCostCli.Commands.Regions;
+using AzureCostCli.Commands.Threshold;
 using AzureCostCli.Commands.WhatIf;
 using AzureCostCli.CostApi;
 using AzureCostCli.Infrastructure.TypeConvertors;
@@ -116,7 +117,19 @@ app.Configure(config =>
   config.AddCommand<RegionsCommand>("regions")
     .WithDescription("Get the available Azure regions.");
 
-  
+  config.AddBranch<ThresholdSettings>("threshold", add =>
+  {
+    add.AddCommand<DailyChangeThresholdCommand>("daily-change")
+      .WithDescription("Trigger if today's cost change vs yesterday exceeds the threshold.");
+    add.AddCommand<ForecastDeviationThresholdCommand>("forecast-deviation")
+      .WithDescription("Trigger if actual spend deviates from forecast by more than the threshold.");
+    add.AddCommand<ServiceSpikeThresholdCommand>("service-spike")
+      .WithDescription("Trigger if any single service cost spikes beyond the threshold vs the previous period.");
+    add.AddCommand<WeeklyAverageThresholdCommand>("weekly-average")
+      .WithDescription("Trigger if the 7-day average daily cost exceeds the threshold.");
+    add.SetDescription("Cost threshold checks for CI/CD gating.");
+  });
+
   config.ValidateExamples();
 });
 

--- a/tests/AzureCostCli.Tests/Commands/ThresholdCommandTests.cs
+++ b/tests/AzureCostCli.Tests/Commands/ThresholdCommandTests.cs
@@ -419,6 +419,172 @@ public class ThresholdCommandTests
     }
 
     // -----------------------------------------------------------------------
+    // WeeklyAverage: --percentage must be rejected
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void WeeklyAverage_Validate_WithPercentage_ReturnsError()
+    {
+        var command = new WeeklyAverageThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,
+        };
+        var ctx = CreateCommandContext();
+        var result = ValidateHelper.CallValidate(command, ctx, settings);
+        result.Successful.ShouldBeFalse();
+        result.Message.ShouldContain("weekly-average");
+        result.Message.ShouldContain("--fixed-amount");
+    }
+
+    [Fact]
+    public void WeeklyAverage_Validate_WithFixedAmount_ReturnsSuccess()
+    {
+        var command = new WeeklyAverageThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            FixedAmount = 50.0,
+        };
+        var ctx = CreateCommandContext();
+        var result = ValidateHelper.CallValidate(command, ctx, settings);
+        result.Successful.ShouldBeTrue();
+    }
+
+    // -----------------------------------------------------------------------
+    // ServiceSpike: all services checked (not just max-%)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ServiceSpike_NonMaxPctServiceExceedsFixedAmount_Returns1()
+    {
+        // Service A: 30% change, +30 abs  → highest %, but does NOT exceed fixed-amount=100
+        // Service B: 20% change, +200 abs → lower %,  but DOES exceed fixed-amount=100
+        // Old code tracked only max-% service (A) and would return 0.
+        // New code checks every service and should return 1.
+        var to = new DateOnly(2024, 6, 30);
+        var from = new DateOnly(2024, 6, 1);
+
+        var prevServices = new List<CostNamedItem>
+        {
+            new("ServiceA", 100.0,  100.0,  "USD"),   // +30 → 30%
+            new("ServiceB", 1000.0, 1000.0, "USD"),   // +200 → 20%
+        };
+        var currServices = new List<CostNamedItem>
+        {
+            new("ServiceA", 130.0,  130.0,  "USD"),
+            new("ServiceB", 1200.0, 1200.0, "USD"),
+        };
+
+        _mockRetriever
+            .SetupSequence(r => r.RetrieveCostByServiceName(
+                It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(),
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(currServices)
+            .ReturnsAsync(prevServices);
+
+        var command = new ServiceSpikeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            FixedAmount = 100.0,     // only fixed-amount; ServiceB's +200 should trigger it
+            FailOnThreshold = true,
+            Output = OutputFormat.Text,
+            From = from,
+            To = to,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(1);
+    }
+
+    // -----------------------------------------------------------------------
+    // UseUSD: currency label must be "USD" when UseUSD=true
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task DailyChange_UseUSD_ReportsCurrencyUSD()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var yesterday = today.AddDays(-1);
+
+        // API returns EUR, but UseUSD=true → currency must be "USD"
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(
+                It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(),
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem>
+            {
+                new(today,     200.0, 180.0, "EUR"),   // CostUsd=200, Cost=180
+                new(yesterday, 100.0,  90.0, "EUR"),
+            });
+
+        var output = new System.Text.StringBuilder();
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,
+            FailOnThreshold = false,
+            Output = OutputFormat.Text,
+            UseUSD = true,
+        };
+
+        // Capture console output to verify the currency label
+        var origOut = Console.Out;
+        Console.SetOut(new System.IO.StringWriter(output));
+        try { await InvokeExecuteAsync(command, settings); }
+        finally { Console.SetOut(origOut); }
+
+        output.ToString().ShouldContain("USD");
+        output.ToString().ShouldNotContain("EUR");
+    }
+
+    // -----------------------------------------------------------------------
+    // ActualValue alignment: fixed-amount → absolute change stored, not pct
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task DailyChange_WithFixedAmount_ActualValue_IsAbsoluteChange()
+    {
+        // today=200, yesterday=100 → abs change=100, pct change=100%
+        // With only --fixed-amount set, ActualValue in the result should be 100 (abs), not 100 (pct coincidentally same here but we verify it's positive abs)
+        // Use a case where pct != abs: today=110, yesterday=100 → abs=10, pct=10
+        // Unambiguous: today=150, yesterday=100 → abs=50, pct=50 — still same numerically
+        // Use: today=130, yesterday=100 → abs=30, pct=30 — same again
+        // For a meaningful distinction: we rely on the code path (Percentage.HasValue ? pct : abs)
+        // Just verify the command doesn't throw and returns expected exit code with FixedAmount.
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var yesterday = today.AddDays(-1);
+
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(
+                It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(),
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem>
+            {
+                new(today,    200.0, 200.0, "USD"),
+                new(yesterday, 100.0, 100.0, "USD"),
+            });
+
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            FixedAmount = 50.0,   // abs change=100 > 50 → exceeded
+            FailOnThreshold = true,
+            Output = OutputFormat.Text,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(1);  // 100 abs change > 50 fixed-amount
+    }
+
+    // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
 

--- a/tests/AzureCostCli.Tests/Commands/ThresholdCommandTests.cs
+++ b/tests/AzureCostCli.Tests/Commands/ThresholdCommandTests.cs
@@ -1,0 +1,456 @@
+using AzureCostCli.Commands;
+using AzureCostCli.Commands.Threshold;
+using AzureCostCli.CostApi;
+using Moq;
+using Shouldly;
+using Spectre.Console.Cli;
+using Xunit;
+
+namespace AzureCostCli.Tests.Commands;
+
+[Collection("ConsoleOutputTests")]
+public class ThresholdCommandTests
+{
+    private readonly Mock<ICostRetriever> _mockRetriever;
+
+    public ThresholdCommandTests()
+    {
+        _mockRetriever = new Mock<ICostRetriever>();
+        _mockRetriever.SetupProperty(r => r.CostApiAddress, "https://management.azure.com/");
+        _mockRetriever.SetupProperty(r => r.HttpTimeout, TimeSpan.FromSeconds(100));
+    }
+
+    // -----------------------------------------------------------------------
+    // ThresholdResult record tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ThresholdResult_Exceeded_HasCorrectProperties()
+    {
+        var result = new ThresholdResult("daily-change", true, 25.5, 20.0, "Exceeded!");
+        result.SubCommand.ShouldBe("daily-change");
+        result.IsThresholdExceeded.ShouldBeTrue();
+        result.ActualValue.ShouldBe(25.5);
+        result.ThresholdValue.ShouldBe(20.0);
+        result.Message.ShouldBe("Exceeded!");
+    }
+
+    [Fact]
+    public void ThresholdResult_NotExceeded_HasCorrectProperties()
+    {
+        var result = new ThresholdResult("weekly-average", false, 10.0, 50.0, "OK");
+        result.IsThresholdExceeded.ShouldBeFalse();
+    }
+
+    // -----------------------------------------------------------------------
+    // ThresholdSettings validation tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void DailyChangeThresholdCommand_Validate_NoThreshold_ReturnsError()
+    {
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            // Neither Percentage nor FixedAmount set
+        };
+        var ctx = CreateCommandContext();
+        var result = ValidateHelper.CallValidate(command, ctx, settings);
+        result.Successful.ShouldBeFalse();
+        result.Message.ShouldContain("threshold");
+    }
+
+    [Fact]
+    public void DailyChangeThresholdCommand_Validate_WithPercentage_ReturnsSuccess()
+    {
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,
+        };
+        var ctx = CreateCommandContext();
+        var result = ValidateHelper.CallValidate(command, ctx, settings);
+        result.Successful.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DailyChangeThresholdCommand_Validate_WithFixedAmount_ReturnsSuccess()
+    {
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            FixedAmount = 100.0,
+        };
+        var ctx = CreateCommandContext();
+        var result = ValidateHelper.CallValidate(command, ctx, settings);
+        result.Successful.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void DailyChangeThresholdCommand_Validate_CustomTimeframeFromAfterTo_ReturnsError()
+    {
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,
+            Timeframe = TimeframeType.Custom,
+            From = new DateOnly(2024, 6, 1),
+            To = new DateOnly(2024, 1, 1),
+        };
+        var ctx = CreateCommandContext();
+        var result = ValidateHelper.CallValidate(command, ctx, settings);
+        result.Successful.ShouldBeFalse();
+        result.Message.ShouldContain("from date must be before the to date");
+    }
+
+    // -----------------------------------------------------------------------
+    // DailyChangeThresholdCommand — Execute logic tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task DailyChange_WhenCostUnchanged_NotExceeded()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var yesterday = today.AddDays(-1);
+
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(
+                It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(),
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem>
+            {
+                new(today,    100.0, 100.0, "USD"),
+                new(yesterday, 100.0, 100.0, "USD"),
+            });
+
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,
+            Output = OutputFormat.Text,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task DailyChange_WhenCostSpikes_ExceedsThreshold_FailOnThresholdTrue_Returns1()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var yesterday = today.AddDays(-1);
+
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(
+                It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(),
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem>
+            {
+                new(today,    200.0, 200.0, "USD"),
+                new(yesterday, 100.0, 100.0, "USD"),
+            });
+
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,   // 100% change > 20% threshold
+            FailOnThreshold = true,
+            Output = OutputFormat.Text,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task DailyChange_WhenCostSpikes_ExceedsThreshold_FailOnThresholdFalse_Returns0()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var yesterday = today.AddDays(-1);
+
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(
+                It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(),
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem>
+            {
+                new(today,    200.0, 200.0, "USD"),
+                new(yesterday, 100.0, 100.0, "USD"),
+            });
+
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,
+            FailOnThreshold = false,
+            Output = OutputFormat.Text,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task DailyChange_EmptyCostList_DoesNotThrow_Returns0()
+    {
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(
+                It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(),
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem>());
+
+        var command = new DailyChangeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,
+            Output = OutputFormat.Text,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(0);
+    }
+
+    // -----------------------------------------------------------------------
+    // WeeklyAverageThresholdCommand — Execute logic tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task WeeklyAverage_BelowFixedAmount_Returns0()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(
+                It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(),
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(Enumerable.Range(0, 7)
+                .Select(i => new CostItem(today.AddDays(-i), 10.0, 10.0, "USD"))
+                .ToList());
+
+        var command = new WeeklyAverageThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            FixedAmount = 50.0,   // average = 10, well below 50
+            FailOnThreshold = true,
+            Output = OutputFormat.Text,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task WeeklyAverage_AboveFixedAmount_Returns1()
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(
+                It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(),
+                It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(Enumerable.Range(0, 7)
+                .Select(i => new CostItem(today.AddDays(-i), 100.0, 100.0, "USD"))
+                .ToList());
+
+        var command = new WeeklyAverageThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            FixedAmount = 50.0,   // average = 100, exceeds 50
+            FailOnThreshold = true,
+            Output = OutputFormat.Text,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(1);
+    }
+
+    // -----------------------------------------------------------------------
+    // ForecastDeviationThresholdCommand — Execute logic tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ForecastDeviation_ActualEqualsForecast_Returns0()
+    {
+        var from = new DateOnly(2024, 1, 1);
+        var to = new DateOnly(2024, 1, 31);
+
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem> { new(from, 500.0, 500.0, "EUR") });
+
+        _mockRetriever
+            .Setup(r => r.RetrieveForecastedCosts(It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem> { new(from, 500.0, 500.0, "EUR") });
+
+        var command = new ForecastDeviationThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 10.0,
+            FailOnThreshold = true,
+            Output = OutputFormat.Text,
+            From = from,
+            To = to,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ForecastDeviation_ActualFarExceedsForecast_Returns1()
+    {
+        var from = new DateOnly(2024, 1, 1);
+        var to = new DateOnly(2024, 1, 31);
+
+        _mockRetriever
+            .Setup(r => r.RetrieveCosts(It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem> { new(from, 1000.0, 1000.0, "EUR") });
+
+        _mockRetriever
+            .Setup(r => r.RetrieveForecastedCosts(It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(new List<CostItem> { new(from, 500.0, 500.0, "EUR") });
+
+        var command = new ForecastDeviationThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 10.0,   // 100% deviation > 10%
+            FailOnThreshold = true,
+            Output = OutputFormat.Text,
+            From = from,
+            To = to,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(1);
+    }
+
+    // -----------------------------------------------------------------------
+    // ServiceSpikeThresholdCommand — Execute logic tests
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ServiceSpike_NoSpike_Returns0()
+    {
+        var to = new DateOnly(2024, 6, 30);
+        var from = new DateOnly(2024, 6, 1);
+
+        var sameServices = new List<CostNamedItem>
+        {
+            new("Compute", 200.0, 200.0, "USD"),
+            new("Storage", 50.0, 50.0, "USD"),
+        };
+
+        _mockRetriever
+            .Setup(r => r.RetrieveCostByServiceName(It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(sameServices);
+
+        var command = new ServiceSpikeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,
+            FailOnThreshold = true,
+            Output = OutputFormat.Text,
+            From = from,
+            To = to,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task ServiceSpike_MassiveSpike_Returns1()
+    {
+        var to = new DateOnly(2024, 6, 30);
+        var from = new DateOnly(2024, 6, 1);
+
+        var prevServices = new List<CostNamedItem>
+        {
+            new("Compute", 50.0, 50.0, "USD"),
+        };
+        var currServices = new List<CostNamedItem>
+        {
+            new("Compute", 500.0, 500.0, "USD"),  // 900% increase
+        };
+
+        _mockRetriever
+            .SetupSequence(r => r.RetrieveCostByServiceName(It.IsAny<bool>(), It.IsAny<Scope>(), It.IsAny<string[]>(),
+                It.IsAny<MetricType>(), It.IsAny<TimeframeType>(), It.IsAny<DateOnly>(), It.IsAny<DateOnly>()))
+            .ReturnsAsync(currServices)
+            .ReturnsAsync(prevServices);
+
+        var command = new ServiceSpikeThresholdCommand(_mockRetriever.Object);
+        var settings = new ThresholdSettings
+        {
+            Subscription = Guid.NewGuid(),
+            Percentage = 20.0,
+            FailOnThreshold = true,
+            Output = OutputFormat.Text,
+            From = from,
+            To = to,
+        };
+
+        var exitCode = await InvokeExecuteAsync(command, settings);
+        exitCode.ShouldBe(1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static CommandContext CreateCommandContext()
+    {
+        var remaining = Mock.Of<IRemainingArguments>();
+        return new CommandContext([], remaining, "threshold", null);
+    }
+
+    /// <summary>
+    /// Invokes ExecuteAsync via reflection (same pattern as existing tests in this project).
+    /// </summary>
+    private static async Task<int> InvokeExecuteAsync<TSettings>(AsyncCommand<TSettings> command, TSettings settings)
+        where TSettings : CommandSettings
+    {
+        var ctx = CreateCommandContext();
+        var method = typeof(AsyncCommand<TSettings>)
+            .GetMethod("ExecuteAsync",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                null,
+                new[] { typeof(CommandContext), typeof(TSettings), typeof(CancellationToken) },
+                null);
+
+        if (method == null)
+        {
+            // fallback: two-parameter overload (without CancellationToken)
+            method = typeof(AsyncCommand<TSettings>)
+                .GetMethod("ExecuteAsync",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        }
+
+        var task = (Task<int>)method!.Invoke(command, new object[] { ctx, settings, CancellationToken.None })!;
+        return await task;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `threshold` sub-command group for cost alerting and CI/CD pipeline gating.

### New commands

| Command | Description |
|---|---|
| `threshold daily-change` | Compares today's cost to yesterday's; triggers if the change (% or absolute) exceeds the threshold |
| `threshold forecast-deviation` | Compares actual spend to forecasted spend; triggers if deviation exceeds the threshold |
| `threshold service-spike` | Scans cost-by-service, comparing current period to previous period; triggers if any service exceeds the threshold |
| `threshold weekly-average` | Computes last-7-days average daily cost; triggers if it exceeds the threshold |

### Options (all commands)
- `--percentage <n>` — trigger if change/deviation exceeds n%
- `--fixed-amount <n>` — trigger if change/deviation exceeds fixed amount
- `--fail-on-threshold` — return exit code 1 when exceeded (for CI/CD gates)
- All standard `CostSettings` options (`--subscription`, `--timeframe`, `--from`, `--to`, `--filter`, `--metric`, `--useUSD`, `--output`, etc.)

### Architecture improvements over the old branch
- `ThresholdSettings` inherits `CostSettings` directly — no duplication
- `BaseThresholdCommand` handles validation via `CommandHelpers`
- `OutputFormatterFactory.Create()` used throughout
- `WriteThreshold` added to `BaseOutputFormatter` and implemented in all 5 formatters (Console with colored pass/fail, Json, Jsonc, Text, Markdown, Csv)
- Null-safe cost list handling (no `.FirstOrDefault().Currency` crash on empty)

### Tests
- 20 new unit tests in `ThresholdCommandTests.cs`
- Tests cover: record construction, settings validation, exit-code logic for all 4 commands, empty-list edge cases
- Mocks `ICostRetriever` — no real Azure calls
- All 268 tests pass