### PR TITLE
chore(deps): consolidated dependency updates (supersedes 8 dependabot PRs)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,9 +40,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: |
           8.0.x

--- a/.github/workflows/dotnet-build-on-tag.yml
+++ b/.github/workflows/dotnet-build-on-tag.yml
@@ -27,9 +27,9 @@ jobs:
         working-directory: ./src
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@v6
       with:
         dotnet-version: |
           8.0.x

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: |
           8.0.x

--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -36,7 +36,7 @@ jobs:
         echo "last_month=$first_day..$last_day" >> "$GITHUB_ENV"
 
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@v4
+      uses: github/issue-metrics@v5
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:mivano/azure-cost-cli is:issue created:${{ env.last_month }} -reason:"not planned"'

--- a/src/azure-cost-cli.csproj
+++ b/src/azure-cost-cli.csproj
@@ -31,10 +31,10 @@
       <PackageReference Include="Azure.Identity" Version="1.21.0" />
       <PackageReference Include="CsvHelper" Version="33.1.0" />
       <PackageReference Include="JmesPath.Net" Version="1.1.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.11" />
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
-      <PackageReference Include="Polly" Version="8.6.6" />
+      <PackageReference Include="Polly" Version="8.7.0" />
       <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
       <PackageReference Include="Spectre.Console" Version="0.55.2" />
       <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />

--- a/src/azure-cost-cli.csproj
+++ b/src/azure-cost-cli.csproj
@@ -36,9 +36,9 @@
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
       <PackageReference Include="Polly" Version="8.7.0" />
       <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
-      <PackageReference Include="Spectre.Console" Version="0.55.2" />
+      <PackageReference Include="Spectre.Console" Version="0.57.2" />
       <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
-      <PackageReference Include="Spectre.Console.Json" Version="0.55.2" />
+      <PackageReference Include="Spectre.Console.Json" Version="0.57.2" />
     </ItemGroup>
     
     <ItemGroup>

--- a/tests/AzureCostCli.Tests/AzureCostCli.Tests.csproj
+++ b/tests/AzureCostCli.Tests/AzureCostCli.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,7 +26,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Consolidates the eight open dependabot PRs into one branch, bumping to the **latest stable** version of each package (rather than dependabot's older proposals, which would otherwise be re-opened next cycle).

## NuGet

| Package | From | To | Dependabot PR |
|---|---|---|---|
| Microsoft.Extensions.DependencyInjection (src + tests) | 10.0.8 | **10.0.11** | #336 (proposed 10.0.9) |
| Microsoft.Extensions.Http.Polly | 10.0.8 | **10.0.11** | #337 (proposed 10.0.9) |
| Polly | 8.6.6 | **8.7.0** | #338 |
| Microsoft.NET.Test.Sdk | 18.6.0 | **18.9.0** | #342 (proposed 18.7.0) |
| Spectre.Console | 0.55.2 | **0.57.2** | #340 (proposed 0.57.0) |
| Spectre.Console.Json | 0.55.2 | **0.57.2** | #340 (proposed 0.57.0) |

## GitHub Actions

| Action | From | To | Dependabot PR |
|---|---|---|---|
| actions/checkout | v6 | **v7** | #341 |
| actions/setup-dotnet | v5 | **v6** | #345 |
| github/issue-metrics | v4 | **v5** | #344 |

## Notes on the Spectre bump

`Spectre.Console.Cli` deliberately stays at **0.55.0** — there is no stable 0.56/0.57 release; the package has moved to `1.0.0-alpha.*`. Its nuspec declares `Spectre.Console >= 0.55.0` (a minimum, not an exact pin), so NuGet unifies cleanly on 0.57.2 with no `NU1605`/`NU1608`. `Spectre.Console` and `Spectre.Console.Json` are kept in lockstep, as they must be.

## Action major-version notes

- `actions/setup-dotnet` v6 — ESM migration + dependency upgrades only; no input renames.
- `github/issue-metrics` v5 — the "breaking change" is an internal `github3.py` → `PyGithub` migration; action inputs are unchanged.
- `actions/checkout` v7 — no input changes affecting this repo.

## Verification

- Both target frameworks (`net8.0`, `net10.0`) compile clean — 0 errors, no new NuGet warnings.
- 286/286 tests pass on `net10.0`. (`net8.0` tests could not be executed locally — no .NET 8 runtime on this machine — but the TFM builds; CI covers it.)
- `--help` output with Spectre 0.57.2 is byte-identical to the 0.55.2 output, confirming no rendering regression from the 0.x minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)