### PR TITLE
fix: resolve default subscription from Azure CLI on Windows (#347)

### DIFF
--- a/src/Commands/CommandHelpers.cs
+++ b/src/Commands/CommandHelpers.cs
@@ -18,19 +18,30 @@ public static class CommandHelpers
         if (!isSubscriptionBased || subscription.HasValue)
             return ValidationResult.Success();
 
+        string reason;
+
         try
         {
-            var resolved = Guid.Parse(AzCommand.GetDefaultAzureSubscriptionId());
-            setSubscription(resolved);
-            return ValidationResult.Success();
+            var subscriptionId = AzCommand.GetDefaultAzureSubscriptionId();
+
+            if (Guid.TryParse(subscriptionId, out var resolved))
+            {
+                setSubscription(resolved);
+                return ValidationResult.Success();
+            }
+
+            reason = $"the Azure CLI returned an unexpected subscription ID: '{subscriptionId}'";
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            return ValidationResult.Error(
-                "No subscription ID provided and unable to retrieve from Azure CLI. " +
-                "Please specify a subscription ID using -s or --subscription, " +
-                "or login to Azure CLI using 'az login'. Use --help for more information.");
+            reason = ex.Message;
         }
+
+        return ValidationResult.Error(
+            "No subscription ID provided and unable to retrieve from Azure CLI. " +
+            "Please specify a subscription ID using -s or --subscription, " +
+            "or login to Azure CLI using 'az login'. Use --help for more information. " +
+            $"({reason})");
     }
 
     /// <summary>

--- a/src/Infrastructure/AzCommand.cs
+++ b/src/Infrastructure/AzCommand.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text.Json;
 
@@ -5,43 +6,116 @@ namespace AzureCostCli.Infrastructure;
 
 public static class AzCommand
 {
+    private const string AzArguments = "account show --output json";
+
+    /// <summary>
+    /// How long to wait for the Azure CLI to respond before giving up.
+    /// </summary>
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Builds the start info used to invoke the Azure CLI.
+    /// </summary>
+    /// <remarks>
+    /// On Windows the Azure CLI installed through the MSI or winget is a batch file (az.cmd);
+    /// there is no az.exe. Because UseShellExecute is false, .NET calls CreateProcess directly,
+    /// which only appends .exe, ignores PATHEXT and cannot execute batch files at all. Launching
+    /// through the command interpreter is therefore required, even when 'az' is on the PATH.
+    /// </remarks>
+    internal static ProcessStartInfo BuildStartInfo() => BuildStartInfo(OperatingSystem.IsWindows());
+
+    /// <inheritdoc cref="BuildStartInfo()"/>
+    internal static ProcessStartInfo BuildStartInfo(bool isWindows)
+    {
+        var startInfo = isWindows
+            ? new ProcessStartInfo
+            {
+                FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe",
+                Arguments = $"/c az {AzArguments}"
+            }
+            : new ProcessStartInfo
+            {
+                FileName = "az",
+                Arguments = AzArguments
+            };
+
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        startInfo.UseShellExecute = false;
+        startInfo.CreateNoWindow = true;
+
+        return startInfo;
+    }
+
     public static string GetDefaultAzureSubscriptionId()
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "az",
-            Arguments = "account show",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
+        using var process = new Process { StartInfo = BuildStartInfo() };
 
-        using (var process = new Process { StartInfo = startInfo })
+        try
         {
             process.Start();
-            string output = process.StandardOutput.ReadToEnd();
-            process.WaitForExit();
+        }
+        catch (Win32Exception ex)
+        {
+            throw new Exception(
+                $"Unable to start the Azure CLI ('{process.StartInfo.FileName}'). " +
+                "Make sure the Azure CLI is installed and available on the PATH. " +
+                $"({ex.Message})", ex);
+        }
 
-            if (process.ExitCode != 0)
+        // Both pipes must be drained while the process runs; reading one only after the process
+        // has exited deadlocks as soon as the other pipe buffer fills up, and the Azure CLI does
+        // write upgrade notices and warnings to stderr.
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+
+        if (!process.WaitForExit((int)Timeout.TotalMilliseconds))
+        {
+            try
             {
-                string error = process.StandardError.ReadToEnd();
-                throw new Exception($"Error executing 'az account show': {error}");
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Nothing useful to do if the process cannot be killed.
             }
 
-            using (var jsonDocument = JsonDocument.Parse(output))
-            {
-                JsonElement root = jsonDocument.RootElement;
-                if (root.TryGetProperty("id", out JsonElement idElement))
-                {
-                    string subscriptionId = idElement.GetString();
-                    return subscriptionId;
-                }
-                else
-                {
-                    throw new Exception("Unable to find the 'id' property in the JSON output.");
-                }
-            }
+            throw new Exception(
+                $"Timed out after {Timeout.TotalSeconds:N0} seconds waiting for 'az {AzArguments}'.");
+        }
+
+        var output = outputTask.GetAwaiter().GetResult();
+        var error = errorTask.GetAwaiter().GetResult();
+
+        if (process.ExitCode != 0)
+        {
+            throw new Exception(
+                $"Error executing 'az {AzArguments}' (exit code {process.ExitCode}): {error.Trim()}");
+        }
+
+        using var jsonDocument = ParseJson(output);
+
+        if (jsonDocument.RootElement.TryGetProperty("id", out var idElement) &&
+            idElement.GetString() is { Length: > 0 } subscriptionId)
+        {
+            return subscriptionId;
+        }
+
+        throw new Exception("Unable to find the 'id' property in the JSON output.");
+    }
+
+    private static JsonDocument ParseJson(string output)
+    {
+        try
+        {
+            return JsonDocument.Parse(output);
+        }
+        catch (JsonException ex)
+        {
+            // Most likely an 'output' default configured through 'az configure' or AZURE_CORE_OUTPUT,
+            // which the explicit --output json should already override, but be explicit about it.
+            throw new Exception(
+                $"The output of 'az {AzArguments}' is not valid JSON: {ex.Message}", ex);
         }
     }
 }

--- a/tests/AzureCostCli.Tests/Commands/CommandHelpersTests.cs
+++ b/tests/AzureCostCli.Tests/Commands/CommandHelpersTests.cs
@@ -56,6 +56,23 @@ public class CommandHelpersTests
     }
 
     [Fact]
+    public void ValidateAndResolveSubscription_WhenAzCliResolutionFails_ErrorExplainsWhy()
+    {
+        // Act - environment dependent: az CLI may or may not be present.
+        var result = CommandHelpers.ValidateAndResolveSubscription(
+            subscription: null, isSubscriptionBased: true, _ => { });
+
+        // Assert - a failure must say more than "unable to retrieve"; the underlying
+        // reason is appended in parentheses so the user can actually diagnose it.
+        if (!result.Successful)
+        {
+            result.Message.ShouldNotBeNull();
+            result.Message.ShouldContain("az login");
+            result.Message.ShouldMatch(@"\(.+\)");
+        }
+    }
+
+    [Fact]
     public void ValidateTimeframe_CustomWithValidDates_ReturnsSuccess()
     {
         // Arrange

--- a/tests/AzureCostCli.Tests/Infrastructure/AzCommandTests.cs
+++ b/tests/AzureCostCli.Tests/Infrastructure/AzCommandTests.cs
@@ -1,0 +1,59 @@
+using AzureCostCli.Infrastructure;
+using Shouldly;
+
+namespace AzureCostCli.Tests.Infrastructure;
+
+public class AzCommandTests
+{
+    [Fact]
+    public void BuildStartInfo_AlwaysRequestsJsonOutput()
+    {
+        // A user with 'az configure --defaults output=table' (or AZURE_CORE_OUTPUT=table)
+        // would otherwise get non-JSON back, which fails to parse.
+        var startInfo = AzCommand.BuildStartInfo();
+
+        startInfo.Arguments.ShouldContain("account show");
+        startInfo.Arguments.ShouldContain("--output json");
+    }
+
+    [Fact]
+    public void BuildStartInfo_RedirectsBothStreamsWithoutShellExecute()
+    {
+        var startInfo = AzCommand.BuildStartInfo();
+
+        startInfo.RedirectStandardOutput.ShouldBeTrue();
+        startInfo.RedirectStandardError.ShouldBeTrue();
+        startInfo.UseShellExecute.ShouldBeFalse();
+        startInfo.CreateNoWindow.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void BuildStartInfo_OnWindows_LaunchesThroughCommandInterpreter()
+    {
+        // The MSI/winget Azure CLI is az.cmd; CreateProcess cannot execute batch files,
+        // so it has to go through the command interpreter. See issue #347.
+        var startInfo = AzCommand.BuildStartInfo(isWindows: true);
+
+        startInfo.FileName.ShouldContain("cmd", Case.Insensitive);
+        startInfo.Arguments.ShouldBe("/c az account show --output json");
+    }
+
+    [Fact]
+    public void BuildStartInfo_OnNonWindows_InvokesAzDirectly()
+    {
+        var startInfo = AzCommand.BuildStartInfo(isWindows: false);
+
+        startInfo.FileName.ShouldBe("az");
+        startInfo.Arguments.ShouldBe("account show --output json");
+    }
+
+    [Fact]
+    public void BuildStartInfo_DefaultsToTheCurrentOperatingSystem()
+    {
+        var expected = AzCommand.BuildStartInfo(OperatingSystem.IsWindows());
+        var actual = AzCommand.BuildStartInfo();
+
+        actual.FileName.ShouldBe(expected.FileName);
+        actual.Arguments.ShouldBe(expected.Arguments);
+    }
+}


### PR DESCRIPTION
Fixes #347.

## The bug

`AzCommand.GetDefaultAzureSubscriptionId()` launched the Azure CLI with `FileName = "az"` and `UseShellExecute = false`. That routes straight to Win32 `CreateProcess`, which appends only `.exe`, **ignores `PATHEXT`, and cannot execute batch files at all**.

The MSI/winget install of the Azure CLI ships **`az.cmd`** (in `C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin`) — there is no `az.exe`. So `Process.Start()` threw `Win32Exception`, and every subscription-based command failed with "No subscription ID provided and unable to retrieve from Azure CLI" even for users who were correctly logged in via `az login`.

**This was not a PATH problem** — worth stressing, because it's the natural first guess. The reporter ran `az login` successfully, so `az` *was* on PATH; the entry is just a `.cmd` that `CreateProcess` refuses to launch. macOS/Linux were unaffected because `az` is a real executable there, and Chocolatey/scoop installs escaped it because they generate `.exe` shims.

Authentication itself was never affected — `AzureCostApiRetriever` uses `AzureCliCredential`, which resolves `az.cmd` correctly. Only this hand-rolled process launch was broken.

## The fix

On Windows, launch through the command interpreter (`%ComSpec%`, falling back to `cmd.exe`); other platforms keep invoking `az` directly. One fix point covers all 11 commands, since they all funnel through `CommandHelpers.ValidateAndResolveSubscription`.

## Three secondary bugs fixed in the same method

1. **Missing `--output json`** — a user with `az configure --defaults output=table` or `AZURE_CORE_OUTPUT=table` got non-JSON, `JsonDocument.Parse` threw, and they hit the identical generic error. This one is **cross-platform** and independent of #347.
2. **stderr deadlock** — stdout was drained, then `WaitForExit()`, then stderr was read only after exit. If `az` filled the ~4 KB stderr pipe (it writes warnings and upgrade notices there) the child blocked on write while the parent blocked in `WaitForExit`. Both pipes are now drained concurrently, and there's a 30-second timeout where previously a stalled `az` hung the CLI indefinitely.
3. **`Guid.Parse` inside `catch (Exception)`** — this conflated "az is unusable" with "az returned something unexpected", and discarded the reason entirely, so even `--debug` printed nothing useful. Now uses `Guid.TryParse` and appends the underlying cause to the validation error.

### Error messages before / after

Before, every failure mode produced the same line. Now the underlying cause is appended.

Logged out, all platforms:
```
... (Error executing 'az account show --output json' (exit code 1): ERROR: Please run 'az login' to setup account.)
```

`az` not installed — **note the message differs by platform**, since Windows now goes through `cmd.exe`:
```
non-Windows: ... (Unable to start the Azure CLI ('az'). Make sure the Azure CLI is installed and available on the PATH. (...))
Windows:     ... (Error executing 'az account show --output json' (exit code 9009): 'az' is not recognized as an internal or external command...)
```

On Windows `cmd.exe` reports a missing `az` as a non-zero exit rather than failing to start, so the `Win32Exception` branch there fires only if `cmd.exe` itself cannot be launched. Worth knowing when grepping logs from a Windows bug report.

## Testing

`BuildStartInfo` is exposed internally with an explicit `isWindows` flag (the project already has `InternalsVisibleTo AzureCostCli.Tests`), so **the Windows launch path is covered by tests even though CI runs on ubuntu** — otherwise the actual fix would have had zero automated coverage.

- 292 tests pass (286 existing + 6 new).
- Verified manually on macOS: the happy path still auto-resolves the subscription and returns real cost data; the `az`-not-logged-in and `az`-absent paths both produce the new diagnostic messages shown above.
- The Windows runtime behaviour itself could not be executed — no Windows machine available, and CI is ubuntu-only. The argument construction is unit-tested; the `CreateProcess`/`.cmd` interaction is reasoned from the Win32 contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
